### PR TITLE
Online tests for various PHP versions ['5.6', '7.3', '7.4']

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -28,6 +28,8 @@ jobs:
     name: Lint Code Base
     # Set the agent to run on
     runs-on: ubuntu-latest
+    # Limit the running time
+    timeout-minutes: 10
 
     ##################
     # Load all steps #
@@ -52,4 +54,7 @@ jobs:
           VALIDATE_JAVASCRIPT_STANDARD: false
           VALIDATE_ANSIBLE: false
           VALIDATE_CSS: false
+          VALIDATE_JSCPD: false
+          # PHPStan run in matrix strategy in php-composer-phpunit.yml
+          VALIDATE_PHP_PHPSTAN: false
           VALIDATE_PHP_PSALM: false

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         operating-system:
           - "ubuntu-latest"
-        php-version: ['5.3', '5.6', '7.3', '7.4']
+        php-version: ['5.6', '7.3', '7.4']
 
     steps:
     - name: "Checkout"

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -22,6 +22,9 @@ jobs:
         tools: composer:v2, phpstan
         # tools: composer:v2, phpunit
 
+    - name: PHPStan version
+      run: phpstan -V
+
     - name: Validate composer.json and composer.lock
       run: composer validate
 

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -1,13 +1,26 @@
-name: PHP Composer + PHPUnit
+name: PHP Composer + PHPUnit + PHPStan
 
 on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system:
+          - "ubuntu-latest"
+        php-version: ['5.3', '5.6', '7.3', '7.4']
 
     steps:
-    - uses: actions/checkout@v2
+    - name: "Checkout"
+      uses: actions/checkout@v2
+
+    - name: "Install PHP ${{ matrix.php-version }} Test on ${{ matrix.operating-system }}"
+      uses: "shivammathur/setup-php@v2"
+      with:
+        php-version: "${{ matrix.php-version }}"
+        tools: composer:v2
+        # tools: composer:v2, phpunit
 
     - name: Validate composer.json and composer.lock
       run: composer validate
@@ -18,18 +31,31 @@ jobs:
     - name: Install dependencies
       run: composer update --prefer-dist --no-progress
 
-    - name: PHPUnit (php-actions)
-      uses: php-actions/phpunit@v5
-      with:
-        # PHP included in ubuntu-latest does not support iconv //TRANSLIT flag as iconv implementation is unknown
-        # https://github.com/actions/virtual-environments/blob/ubuntu18/20201026.1/images/linux/Ubuntu1804-README.md
-        # therefore PHPUnit group iconvtranslit should be excluded.
-        # Also doesn't make sense to test MySQLi related tests until MySQLi environment is ready.
-        # Also HTTP requests to self can't work in CLI only environment.
-        configuration: phpunit-github-actions.xml
+    - name: "PHPUnit tests"
+      run: "vendor/bin/phpunit"
+
+    #- name: PHPUnit (php-actions)
+    #  uses: php-actions/phpunit@v5
+    #  with:
+    #    # PHP included in ubuntu-latest does not support iconv //TRANSLIT flag as iconv implementation is unknown
+    #    # https://github.com/actions/virtual-environments/blob/ubuntu18/20201026.1/images/linux/Ubuntu1804-README.md
+    #    # therefore PHPUnit group iconvtranslit should be excluded.
+    #    # Also doesn't make sense to test MySQLi related tests until MySQLi environment is ready.
+    #    # Also HTTP requests to self can't work in CLI only environment.
+    #    configuration: phpunit-github-actions.xml
 
     # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
     # Docs: https://getcomposer.org/doc/articles/scripts.md
 
     # - name: Run test suite
     #   run: composer run-script test
+
+    # PHPStan works for PHP/7.1+ so it can't even be in composer.json
+    - name: "PHPStan"
+      if: ${{ matrix.php-version != '5.3' && matrix.php-version != '5.6' }}
+      # alternative syntax # if: ${{ matrix.php-version >= '7.1' }}
+      run: |
+        composer require --dev phpstan/phpstan:^0.12
+        vendor/bin/phpstan analyse --no-interaction --no-progress .
+        # If removal needed:
+        # composer remove --dev phpstan/phpstan

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -19,8 +19,10 @@ jobs:
       uses: "shivammathur/setup-php@v2"
       with:
         php-version: "${{ matrix.php-version }}"
-        tools: composer:v2, phpstan
+        tools: composer:v2
         # tool phpstan fails for PHP/5.6
+        # tool phpstan fails for PHP/5.6; doesn't finish 7.3,7.4 after 30 minutes
+
         # tools: composer:v2, phpunit
 
     #- name: PHPStan version
@@ -59,9 +61,9 @@ jobs:
       # alternative syntax # if: ${{ matrix.php-version != '5.3' && matrix.php-version != '5.6' }}
       if: ${{ matrix.php-version >= '7.1' }}
       run: |
-        #composer require --dev phpstan/phpstan:^0.12
-        #vendor/bin/phpstan analyse --no-interaction --no-progress .
-        phpstan -V
-        phpstan analyse --no-interaction --no-progress .
+        composer require --dev phpstan/phpstan:^0.12
+        vendor/bin/phpstan analyse --no-interaction --no-progress .
+        #phpstan -V
+        #phpstan analyse --no-interaction --no-progress .
         # If removal needed:
         # composer remove --dev phpstan/phpstan

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -61,6 +61,7 @@ jobs:
       run: |
         #composer require --dev phpstan/phpstan:^0.12
         #vendor/bin/phpstan analyse --no-interaction --no-progress .
-        phpstan analyse --no-interaction --no-progress .
+        phpstan -V
+        #phpstan analyse --no-interaction --no-progress .
         # If removal needed:
         # composer remove --dev phpstan/phpstan

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -20,10 +20,11 @@ jobs:
       with:
         php-version: "${{ matrix.php-version }}"
         tools: composer:v2, phpstan
+        # tool phpstan fails for PHP/5.6
         # tools: composer:v2, phpunit
 
-    - name: PHPStan version
-      run: phpstan -V
+    #- name: PHPStan version
+    #  run: phpstan -V
 
     - name: Validate composer.json and composer.lock
       run: composer validate
@@ -55,10 +56,11 @@ jobs:
 
     # PHPStan works for PHP/7.1+ so it can't even be in composer.json
     - name: "PHPStan"
-      if: ${{ matrix.php-version != '5.3' && matrix.php-version != '5.6' }}
-      # alternative syntax # if: ${{ matrix.php-version >= '7.1' }}
+      # alternative syntax # if: ${{ matrix.php-version != '5.3' && matrix.php-version != '5.6' }}
+      if: ${{ matrix.php-version >= '7.1' }}
       run: |
-        composer require --dev phpstan/phpstan:^0.12
-        vendor/bin/phpstan analyse --no-interaction --no-progress .
+        #composer require --dev phpstan/phpstan:^0.12
+        #vendor/bin/phpstan analyse --no-interaction --no-progress .
+        phpstan analyse --no-interaction --no-progress .
         # If removal needed:
         # composer remove --dev phpstan/phpstan

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -5,8 +5,8 @@ jobs:
   build:
 
     runs-on: ${{ matrix.operating-system }}
-    timeout-minutes: 1
-    #301
+    # Limit the running time
+    timeout-minutes: 10
     strategy:
       matrix:
         operating-system:
@@ -21,14 +21,8 @@ jobs:
       uses: "shivammathur/setup-php@v2"
       with:
         php-version: "${{ matrix.php-version }}"
-        tools: composer:v2
-        # tool phpstan fails for PHP/5.6
-        # tool phpstan fails for PHP/5.6; doesn't finish 7.3,7.4 after 30 minutes
-
-        # tools: composer:v2, phpunit
-
-    #- name: PHPStan version
-    #  run: phpstan -V
+        tools: composer:v2, phpstan
+        # Note: phpstan call fails for PHP<7.1
 
     - name: Validate composer.json and composer.lock
       run: composer validate
@@ -39,6 +33,7 @@ jobs:
     - name: Install dependencies
       run: composer update --prefer-dist --no-progress
 
+    # PHPunit is installed anyway, so it doesn't make sense to use tools: phpunit
     - name: "PHPUnit tests"
       run: "vendor/bin/phpunit --configuration phpunit-github-actions.xml"
 
@@ -63,9 +58,9 @@ jobs:
       # alternative syntax # if: ${{ matrix.php-version != '5.3' && matrix.php-version != '5.6' }}
       if: ${{ matrix.php-version >= '7.1' }}
       run: |
-        composer require --dev phpstan/phpstan:^0.12
-        vendor/bin/phpstan analyse --debug .
-        #phpstan -V
-        #phpstan analyse --no-interaction --no-progress .
+        #composer require --dev phpstan/phpstan:^0.12
+        #vendor/bin/phpstan analyse --debug .
         # If removal needed:
         # composer remove --dev phpstan/phpstan
+        #phpstan -V
+        phpstan analyse --no-interaction --no-progress .

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -19,7 +19,7 @@ jobs:
       uses: "shivammathur/setup-php@v2"
       with:
         php-version: "${{ matrix.php-version }}"
-        tools: composer:v2
+        tools: composer:v2, phpstan
         # tools: composer:v2, phpunit
 
     - name: Validate composer.json and composer.lock
@@ -32,7 +32,7 @@ jobs:
       run: composer update --prefer-dist --no-progress
 
     - name: "PHPUnit tests"
-      run: "vendor/bin/phpunit"
+      run: "vendor/bin/phpunit --configuration phpunit-github-actions.xml"
 
     #- name: PHPUnit (php-actions)
     #  uses: php-actions/phpunit@v5

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -62,7 +62,7 @@ jobs:
       if: ${{ matrix.php-version >= '7.1' }}
       run: |
         composer require --dev phpstan/phpstan:^0.12
-        vendor/bin/phpstan analyse --no-interaction --no-progress .
+        vendor/bin/phpstan analyse .
         #phpstan -V
         #phpstan analyse --no-interaction --no-progress .
         # If removal needed:

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -62,6 +62,6 @@ jobs:
         #composer require --dev phpstan/phpstan:^0.12
         #vendor/bin/phpstan analyse --no-interaction --no-progress .
         phpstan -V
-        #phpstan analyse --no-interaction --no-progress .
+        phpstan analyse --no-interaction --no-progress .
         # If removal needed:
         # composer remove --dev phpstan/phpstan

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -5,6 +5,8 @@ jobs:
   build:
 
     runs-on: ${{ matrix.operating-system }}
+    timeout-minutes: 1
+    #301
     strategy:
       matrix:
         operating-system:
@@ -62,7 +64,7 @@ jobs:
       if: ${{ matrix.php-version >= '7.1' }}
       run: |
         composer require --dev phpstan/phpstan:^0.12
-        vendor/bin/phpstan analyse .
+        vendor/bin/phpstan analyse --debug .
         #phpstan -V
         #phpstan analyse --no-interaction --no-progress .
         # If removal needed:

--- a/.github/workflows/phplint.yml
+++ b/.github/workflows/phplint.yml
@@ -3,6 +3,8 @@ on: [push, pull_request]
 jobs:
   phplint:
     runs-on: ubuntu-latest
+    # Limit the running time
+    timeout-minutes: 10
     steps:
         - uses: actions/checkout@v2
         - uses: michaelw90/PHP-Lint@master

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "godsdev/mycms",
-    "description": "MyCMS",
+    "description": "MyCMS - Brief MVC framework for interactive websites including general administration.",
     "type": "library",
     "require": {
         "php": "^5.6 || ^7.0",

--- a/conf/phpstan.common.neon
+++ b/conf/phpstan.common.neon
@@ -3,7 +3,6 @@ parameters:
     excludePaths:
         analyse:
           - ../vendor
-     #   analyseAndScananalyseAndScaanalyseAndScanalyseAndSanalyseAndanalyseAn
     bootstrapFiles:
       - config.php
       #- ../.github/linters/conf/constants.php # uncomment if needed

--- a/conf/phpstan.common.neon
+++ b/conf/phpstan.common.neon
@@ -1,5 +1,9 @@
 parameters:
     level: 5
+    excludePaths:
+        analyse:
+          - ../vendor
+     #   analyseAndScananalyseAndScaanalyseAndScanalyseAndSanalyseAndanalyseAn
     bootstrapFiles:
       - config.php
       #- ../.github/linters/conf/constants.php # uncomment if needed

--- a/dist/.github/workflows/linter.yml
+++ b/dist/.github/workflows/linter.yml
@@ -28,6 +28,8 @@ jobs:
     name: Lint Code Base
     # Set the agent to run on
     runs-on: ubuntu-latest
+    # Limit the running time
+    timeout-minutes: 10
 
     ##################
     # Load all steps #
@@ -52,4 +54,6 @@ jobs:
           VALIDATE_JAVASCRIPT_STANDARD: false
           VALIDATE_ANSIBLE: false
           VALIDATE_CSS: false
+          # PHPStan run in matrix strategy in php-composer-phpunit.yml
+          #TODO: VALIDATE_PHP_PHPSTAN: false
           VALIDATE_PHP_PSALM: false

--- a/dist/.github/workflows/php-composer-dependencies.yml
+++ b/dist/.github/workflows/php-composer-dependencies.yml
@@ -16,6 +16,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    # Limit the running time
+    timeout-minutes: 10
 
     steps:
     - uses: actions/checkout@v2
@@ -34,3 +36,5 @@ jobs:
 
     # - name: Run test suite
     #   run: composer run-script test
+
+    # TODO: add matrix strategy + PHPUnit + PHPStan

--- a/dist/.github/workflows/phplint.yml
+++ b/dist/.github/workflows/phplint.yml
@@ -3,6 +3,8 @@ on: [push, pull_request]
 jobs:
   phplint:
     runs-on: ubuntu-latest
+    # Limit the running time
+    timeout-minutes: 10
     steps:
         - uses: actions/checkout@v2
         - uses: michaelw90/PHP-Lint@master

--- a/dist/conf/phpstan.common.neon
+++ b/dist/conf/phpstan.common.neon
@@ -1,5 +1,8 @@
 parameters:
     level: 5
+    excludePaths:
+        analyse:
+          - ../vendor
     bootstrapFiles:
       - config.php
       #- config.local.dist.php # comment as debugging

--- a/dist/phpstan.neon.dist
+++ b/dist/phpstan.neon.dist
@@ -2,8 +2,9 @@ includes:
       - conf/phpstan.common.neon
 
 parameters:
-    excludes_analyse:
-      - cache/*
+    excludePaths:
+        analyseAndScan:
+            - cache/*
     dynamicConstantNames:
       - FORCE_301
       - FRIENDLY_URL


### PR DESCRIPTION
* Online tests for various PHP versions ['5.6', '7.3', '7.4']
* PHPStan works for PHP/7.1+ so it can't even be in composer.json
* PHPUnit config simple tests
* Limit the GitHub action job running time
* VALIDATE_JSCPD: false - TODO correct this
* VALIDATE_PHP_PHPSTAN: false # PHPStan run in matrix strategy in php-composer-phpunit.yml
* PHPStan online runs as a tool (not a composer required-dev library)
