### PR TITLE
changed DATETIME (datatype) to TIMESTAMP for

### DIFF
--- a/dist/db/migrations/20200607165705_redirector_table.php
+++ b/dist/db/migrations/20200607165705_redirector_table.php
@@ -37,7 +37,9 @@ class RedirectorTable extends AbstractMigration
             ->addColumn('old_url', 'string', ['limit' => 500, 'comment' => 'URL to be redirected', 'null' => false])
             ->addIndex('old_url')
             ->addColumn('new_url', 'string', ['limit' => 500, 'comment' => 'Target URL', 'null' => false])
-            ->addColumn('added', 'datetime', ['comment' => 'Creation timestamp', 'default' => 'CURRENT_TIMESTAMP', 'null' => false])
+            // The DEFAULT CURRENT_TIMESTAMP support for a DATETIME (datatype) was added in MySQL 5.6.
+            // In 5.5 and earlier versions, this applied only to TIMESTAMP (datatype) columns.
+            ->addColumn('added', 'timestamp', ['comment' => 'Creation timestamp', 'default' => 'CURRENT_TIMESTAMP', 'null' => false])
             ->addColumn('active', 'boolean', ['comment' => '0=inactive, 1=active', 'default' => 1])
             ->create();
     }

--- a/dist/db/migrations/20200607204634_content_table.php
+++ b/dist/db/migrations/20200607204634_content_table.php
@@ -56,7 +56,7 @@ class ContentTable extends AbstractMigration
         }
 
         $content
-            ->addColumn('added', 'datetime', ['comment' => 'Creation timestamp', 'default' => 'CURRENT_TIMESTAMP', 'null' => false])
+            ->addColumn('added', 'timestamp', ['comment' => 'Creation timestamp', 'default' => 'CURRENT_TIMESTAMP', 'null' => false])
             ->addColumn('context', 'string', ['comment' => '{"edit":"json"}', 'limit' => 4096, 'null' => false,])
             ->addColumn('sort', 'integer', ['comment' => 'sort order', 'default' => 0, 'limit' => MysqlAdapter::INT_SMALL, 'null' => false,])
             ->addColumn('active', 'boolean', ['comment' => '0=inactive, 1=active', 'default' => 1])
@@ -83,7 +83,7 @@ class ContentTable extends AbstractMigration
         }
 
         $category
-            ->addColumn('added', 'datetime', ['comment' => 'Creation timestamp', 'default' => 'CURRENT_TIMESTAMP', 'null' => false])
+            ->addColumn('added', 'timestamp', ['comment' => 'Creation timestamp', 'default' => 'CURRENT_TIMESTAMP', 'null' => false])
             ->addColumn('context', 'string', ['comment' => '{"edit":"json"}', 'default' => '{}', 'limit' => 4096, 'null' => false,])
             ->addColumn('sort', 'integer', ['comment' => 'sort order', 'default' => 0, 'limit' => MysqlAdapter::INT_SMALL, 'null' => false,])
             ->addColumn('active', 'boolean', ['comment' => '0=inactive, 1=active', 'default' => 1])
@@ -112,7 +112,7 @@ class ContentTable extends AbstractMigration
         }
 
         $product
-            ->addColumn('added', 'datetime', ['comment' => 'Creation timestamp', 'default' => 'CURRENT_TIMESTAMP', 'null' => false])
+            ->addColumn('added', 'timestamp', ['comment' => 'Creation timestamp', 'default' => 'CURRENT_TIMESTAMP', 'null' => false])
             ->addColumn('context', 'string', ['comment' => '{"edit":"json"}', 'limit' => 4096, 'null' => false,])
             ->addColumn('sort', 'integer', ['comment' => 'sort order', 'default' => 0, 'limit' => MysqlAdapter::INT_SMALL, 'null' => false,])
             ->addColumn('active', 'boolean', ['comment' => '0=inactive, 1=active', 'default' => 1])

--- a/dist/db/migrations/20200703213436_content_example.php
+++ b/dist/db/migrations/20200703213436_content_example.php
@@ -20,6 +20,7 @@ final class ContentExample extends AbstractMigration
      */
     public function change() //: void
     {
+        // Note: generates several `PHP Notice:  Constant` but it is required to set again `$myCmsConf`
         require __DIR__ . '/../../conf/config.php';
         $languages = array_keys($myCmsConf['TRANSLATIONS']);
         sort($languages);


### PR DESCRIPTION
a) better compatibility as the DEFAULT CURRENT_TIMESTAMP support for a DATETIME (datatype) was added in MySQL 5.6. In 5.5 and earlier versions, this applied only to TIMESTAMP (datatype) columns.
b) MySQL converts TIMESTAMP values from the current time zone to UTC for storage, and back from UTC to the current time zone for retrieval. (This does not occur for other types such as DATETIME.)”.
An important difference is that DATETIME represents a date (as found in a calendar) and a time (as can be observed on a wall clock), while TIMESTAMP represents a well defined point in time. This could be very important if your application handles time zones.