### PR TITLE
dist composer check + GodsDev\Backyard to WorkOfStan\Backyard

### DIFF
--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -75,18 +75,19 @@ jobs:
         composer update --no-dev --prefer-dist --no-progress
         composer update --prefer-dist --no-progress
         # TODO: make dist ready for automated testing (database + htaccess)
-        cd .. # redundant as each run starts in the root
+        # `cd ..` redundant as each run starts in the root
+        cd ..
 
     # PHPStan works for PHP/7.1+ so it can't even be in composer.json
-    - name: "Composer + PHPStan (app)"
+    - name: "PHPStan (app)"
       if: ${{ matrix.php-version >= '7.1' }}
       run: |
         cd dist
-        #to fix `Constant DB_USERNAME not found.` etc
+        # to fix `Constant DB_USERNAME not found.` etc
         cp -p conf/config.local.dist.php conf/config.local.php
-        #todo look if only one thing added
+        # Only phpstan/phpstan-webmozart-assert + phpstan/phpstan added
         composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
-        #todo if above ok, then update also library+app
+        # Note that phpstan/phpstan is required above but not used below (as shivammathur/setup-php tool is used)
         phpstan --configuration=conf/phpstan.webmozart-assert.neon analyse --no-interaction --no-progress .
         cd ..
 

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -68,28 +68,38 @@ jobs:
     # - name: Run test suite
     #   run: composer run-script test
 
+    - name: Switch to app
+      run: cd dist
+
+    - name: Validate composer.json (app)
+      run: composer validate
+
+    - name: Install no-dev dependencies (app)
+      run: composer update --no-dev --prefer-dist --no-progress
+
+    - name: Install dependencies (app)
+      run: composer update --prefer-dist --no-progress
+
+    # PHPunit is installed anyway, so it doesn't make sense to use tools: phpunit
+    - name: "PHPUnit tests (app)"
+      run: "vendor/bin/phpunit"
+
     # PHPStan works for PHP/7.1+ so it can't even be in composer.json
     - name: "Composer + PHPStan (app)"
       if: ${{ matrix.php-version >= '7.1' }}
       run: |
         #to fix `Constant DB_USERNAME not found.` etc
-        cp -p dist/conf/config.local.dist.php dist/conf/config.local.php
-        cd dist
-        #maybe not needed?#composer update --prefer-dist --no-progress
+        cp -p conf/config.local.dist.php conf/config.local.php
+        #todo look if only one thing added
         composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
         #todo if above ok, then update also library+app
         phpstan --configuration=conf/phpstan.webmozart-assert.neon analyse --no-interaction --no-progress .
-        cd ..
+
+    - name: Switch back to library level
+      run: cd ..
 
     - name: "PHPStan (library + app)"
       # alternative syntax # if: ${{ matrix.php-version != '5.3' && matrix.php-version != '5.6' }}
       if: ${{ matrix.php-version >= '7.1' }}
       run: |
-        #to fix `Constant DB_USERNAME not found.` etc
-        #cp -p dist/conf/config.local.dist.php dist/conf/config.local.php
-        #composer require --dev phpstan/phpstan:^0.12
-        #vendor/bin/phpstan analyse --debug .
-        # If removal needed:
-        # composer remove --dev phpstan/phpstan
-        #phpstan -V
         phpstan analyse --no-interaction --no-progress .

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -79,10 +79,7 @@ jobs:
 
     - name: Install dependencies (app)
       run: composer update --prefer-dist --no-progress
-
-    # PHPunit is installed anyway, so it doesn't make sense to use tools: phpunit
-    - name: "PHPUnit tests (app)"
-      run: "vendor/bin/phpunit"
+      # TODO: make dist ready for automated testing (database + htaccess)
 
     # PHPStan works for PHP/7.1+ so it can't even be in composer.json
     - name: "Composer + PHPStan (app)"

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Install no-dev dependencies
       run: composer update --no-dev --prefer-dist --no-progress
 
-    - name: Install dependencies
+    - name: Install dev dependencies
       run: composer update --prefer-dist --no-progress
 
     # PHPunit is installed anyway, so it doesn't make sense to use tools: phpunit
@@ -68,32 +68,27 @@ jobs:
     # - name: Run test suite
     #   run: composer run-script test
 
-    - name: Switch to app
-      run: cd dist
-
-    - name: Validate composer.json (app)
-      run: composer validate
-
-    - name: Install no-dev dependencies (app)
-      run: composer update --no-dev --prefer-dist --no-progress
-
-    - name: Install dependencies (app)
-      run: composer update --prefer-dist --no-progress
-      # TODO: make dist ready for automated testing (database + htaccess)
+    - name: Validate composer.json + install no-dev, then dev dependencies (app)
+      run: |
+        cd dist
+        composer validate
+        composer update --no-dev --prefer-dist --no-progress
+        composer update --prefer-dist --no-progress
+        # TODO: make dist ready for automated testing (database + htaccess)
+        cd .. # redundant as each run starts in the root
 
     # PHPStan works for PHP/7.1+ so it can't even be in composer.json
     - name: "Composer + PHPStan (app)"
       if: ${{ matrix.php-version >= '7.1' }}
       run: |
+        cd dist
         #to fix `Constant DB_USERNAME not found.` etc
         cp -p conf/config.local.dist.php conf/config.local.php
         #todo look if only one thing added
         composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
         #todo if above ok, then update also library+app
         phpstan --configuration=conf/phpstan.webmozart-assert.neon analyse --no-interaction --no-progress .
-
-    - name: Switch back to library level
-      run: cd ..
+        cd ..
 
     - name: "PHPStan (library + app)"
       # alternative syntax # if: ${{ matrix.php-version != '5.3' && matrix.php-version != '5.6' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Many elements ordered alphabetically for better readability
 - `return;` statement after method with @return never is not necessary
 - dist: favicons moved to images/favicon subfolder
+- bump "godsdev/backyard": "^3.2.10" -> "workofstan/backyard": "^3.3.0" to use better tested code limited by php: ^5.3 || ^7.0
 
 ### Fixed
 - Stricter code by type assertion, type casting, type hinting
@@ -96,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MyTableLister::bulkUpdateSQL() should return string but return statement is missing.
 - MyTableLister::contentByType() always returns string (as if $options['return-output'] === true). Performing echo is responsibility of the calling method.
 - process.php: \_SESSION and \_POST attributes processing fixed
+- dist require "symfony/yaml": "^3.4.47|^4|^5|^6" so that it is loaded not only as part of require-dev phpunit/phpunit
 
 ### Deprecated
 - MyTableAdmin::outputSelectPath() - is this function necessary?

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ MyCMS is designed to be used with following technologies:
 - [Tracy](https://github.com/nette/tracy): for debugging
 - [Nette\SmartObject](https://doc.nette.org/en/3.0/smartobject): for ensuring strict PHP rules
 - [Psr\Log\LoggerInterface](https://www.php-fig.org/psr/psr-3/): for logging
-- [GodsDev\Backyard\BackyardMysqli](https://github.com/GodsDev/backyard/blob/master/GodsDev/Backyard/BackyardMysqli.php): for wrapping SQL layer
+- [WorkOfStan\Backyard\BackyardMysqli](https://github.com/WorkOfStan/backyard/blob/main/classes/BackyardMysqli.php): for wrapping SQL layer
 
 ## Installation
 Apache modules `mod_alias` (for hiding non-public files) and `mod_rewrite` (for friendly URL features) are expected.

--- a/Test/MyCMSTest.php
+++ b/Test/MyCMSTest.php
@@ -2,7 +2,7 @@
 
 namespace GodsDev\MyCMS\Test;
 
-use GodsDev\Backyard\Backyard;
+use WorkOfStan\Backyard\Backyard;
 use GodsDev\MyCMS\MyCMS;
 
 require_once __DIR__ . '/../conf/config.php';

--- a/Test/MyControllerTest.php
+++ b/Test/MyControllerTest.php
@@ -2,7 +2,7 @@
 
 namespace GodsDev\MyCMS\Test;
 
-use GodsDev\Backyard\Backyard;
+use WorkOfStan\Backyard\Backyard;
 use GodsDev\MyCMS\MyCMS;
 use GodsDev\MyCMS\MyController;
 

--- a/Test/ProjectCommonTest.php
+++ b/Test/ProjectCommonTest.php
@@ -2,7 +2,7 @@
 
 namespace GodsDev\MyCMS\Test;
 
-use GodsDev\Backyard\Backyard;
+use WorkOfStan\Backyard\Backyard;
 use GodsDev\MyCMS\MyCMS;
 use GodsDev\MyCMS\ProjectCommon;
 use Tracy\Debugger;

--- a/classes/LogMysqli.php
+++ b/classes/LogMysqli.php
@@ -3,7 +3,7 @@
 namespace GodsDev\MyCMS;
 
 use Exception;
-use GodsDev\Backyard\BackyardMysqli;
+use WorkOfStan\Backyard\BackyardMysqli;
 use GodsDev\MyCMS\Tracy\BarPanelTemplate;
 use Tracy\Debugger;
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "nette/utils": "^2.4.8|^3.2.2",
         "texy/texy": "^2.7.1",
         "godsdev/tools": "^0.3.8",
-        "godsdev/backyard": "^3.2.10",
+        "workofstan/backyard": "^3.3.0",
         "ext-session": "*",
         "ext-mbstring": "*"
     },

--- a/dist/README.md
+++ b/dist/README.md
@@ -333,7 +333,7 @@ Logs are in folder `log`:
 * `exception.log` contains fatal errors by Tracy\Debugger
 * `error.log` contains recoverable erros by Tracy\Debugger
 * `debug.log` contains debug info by Tracy\Debugger
-* `backyard-error.log.YYYY-MM.log` by PSR-3 logger implemented in GodsDev\Backyard\BackyardError
+* `backyard-error.log.YYYY-MM.log` by PSR-3 logger implemented in WorkOfStan\Backyard\BackyardError
 * `sqlYYYY-MM-DD.sql` contains content changes by CMS as SQL statements with timestamp
 
 ## Templating

--- a/dist/Test/AdminProcessTest.php
+++ b/dist/Test/AdminProcessTest.php
@@ -2,7 +2,7 @@
 
 namespace GodsDev\mycmsprojectnamespace\Test;
 
-use GodsDev\Backyard\Backyard;
+use WorkOfStan\Backyard\Backyard;
 use GodsDev\MyCMS\LogMysqli;
 use GodsDev\mycmsprojectnamespace\AdminProcess;
 use GodsDev\mycmsprojectnamespace\Init;

--- a/dist/Test/AdminTest.php
+++ b/dist/Test/AdminTest.php
@@ -2,7 +2,7 @@
 
 namespace GodsDev\mycmsprojectnamespace\Test;
 
-use GodsDev\Backyard\Backyard;
+use WorkOfStan\Backyard\Backyard;
 use GodsDev\MyCMS\LogMysqli;
 use GodsDev\mycmsprojectnamespace\Admin;
 use GodsDev\mycmsprojectnamespace\MyCMSProject;

--- a/dist/Test/ControllerTest.php
+++ b/dist/Test/ControllerTest.php
@@ -2,7 +2,7 @@
 
 namespace GodsDev\mycmsprojectnamespace\Test;
 
-use GodsDev\Backyard\Backyard;
+use WorkOfStan\Backyard\Backyard;
 use GodsDev\MyCMS\LogMysqli;
 use GodsDev\mycmsprojectnamespace\Controller;
 use GodsDev\mycmsprojectnamespace\MyCMSProject;

--- a/dist/Test/FaviconTest.php
+++ b/dist/Test/FaviconTest.php
@@ -2,7 +2,7 @@
 
 namespace GodsDev\mycmsprojectnamespace\Test;
 
-use GodsDev\Backyard\Backyard;
+use WorkOfStan\Backyard\Backyard;
 use Tracy\Debugger;
 
 require_once __DIR__ . '/../conf/config.php';

--- a/dist/Test/FriendlyUrlTest.php
+++ b/dist/Test/FriendlyUrlTest.php
@@ -2,7 +2,7 @@
 
 namespace GodsDev\mycmsprojectnamespace\Test;
 
-use GodsDev\Backyard\Backyard;
+use WorkOfStan\Backyard\Backyard;
 use GodsDev\MyCMS\LogMysqli;
 use GodsDev\mycmsprojectnamespace\FriendlyUrl;
 use GodsDev\mycmsprojectnamespace\MyCMSProject;

--- a/dist/composer.json
+++ b/dist/composer.json
@@ -10,10 +10,11 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "godsdev/mycms": "dev-feature/refactoring2103",
+        "godsdev/mycms": "dev-main",
         "robmorgan/phinx": "^0.10.6|^0.12.3",
         "swiftmailer/swiftmailer": "^5.4|^6.2",
-        "webmozart/assert": "^1.9.1"
+        "webmozart/assert": "^1.9.1",
+        "symfony/yaml": "^3.4.47|^4|^5|^6"
     },
     "require-dev": {
         "phpunit/phpunit": "^4|^5"

--- a/dist/composer.json
+++ b/dist/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "godsdev/mycms": "dev-main",
+        "godsdev/mycms": "dev-fix/app-composer-test",
         "robmorgan/phinx": "^0.10.6|^0.12.3",
         "swiftmailer/swiftmailer": "^5.4|^6.2",
         "webmozart/assert": "^1.9.1",

--- a/dist/composer.json
+++ b/dist/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "godsdev/mycms": "dev-fix/app-composer-test",
+        "godsdev/mycms": "dev-main",
         "robmorgan/phinx": "^0.10.6|^0.12.3",
         "swiftmailer/swiftmailer": "^5.4|^6.2",
         "webmozart/assert": "^1.9.1",

--- a/dist/conf/config.php
+++ b/dist/conf/config.php
@@ -24,7 +24,7 @@ define('PATH_MODULE', 10); // length of one node in category.path in digits
 define('RECAPTCHA_KEY', '............');
 define('URL_RECAPTCHA_VERIFY', 'https://www.google.com/recaptcha/api/siteverify');
 //
-//for godsdev/backyard
+//for workofstan/backyard
 $backyardConf = [
     'logging_level' => 3,
     'error_log_message_type' => 3,

--- a/dist/conf/phpstan.app.neon
+++ b/dist/conf/phpstan.app.neon
@@ -11,7 +11,7 @@ parameters:
         #  - ../vendor/composer
         #  - ../vendor/doctrine
         #  - ../vendor/egulias
-        #  - ../vendor/godsdev/backyard
+        #  - ../vendor/workofstan/backyard
         #  - ../vendor/godsdev/mycms/dist
         #  - ../vendor/godsdev/tools
         #  - ../vendor/latte

--- a/dist/prepare.php
+++ b/dist/prepare.php
@@ -9,7 +9,7 @@
 // The Composer auto-loader (official way to load Composer contents) to load external stuff automatically
 require_once __DIR__ . '/vendor/autoload.php';
 
-use GodsDev\Backyard\Backyard;
+use WorkOfStan\Backyard\Backyard;
 use GodsDev\MyCMS\LogMysqli;
 use GodsDev\mycmsprojectnamespace\Init;
 use GodsDev\mycmsprojectnamespace\MyCMSProject;


### PR DESCRIPTION
- added: check also dist for composer validity+dependencies
- changed: bump "godsdev/backyard": "^3.2.10" -> "workofstan/backyard": "^3.3.0" to use better tested code limited by php: ^5.3 || ^7.0 including change of GodsDev\Backyard namespace to WorkOfStan\Backyard
- fixed: dist require "symfony/yaml": "^3.4.47|^4|^5|^6" so that it is loaded not only as part of require-dev phpunit/phpunit
