### PR TITLE
Fix admin table view empty

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,6 +19,11 @@ on:
       # notest branches to ignore testing of partial online commits
       - 'notest/**'
 
+  pull_request:
+    branches-ignore:
+      # notest branches to ignore testing of partial online commits
+      - 'notest/**'
+
 ###############
 # Set the Job #
 ###############
@@ -45,7 +50,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@master
+        uses: github/super-linter@main
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: develop

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -59,6 +59,8 @@ jobs:
           VALIDATE_JAVASCRIPT_STANDARD: false
           VALIDATE_ANSIBLE: false
           VALIDATE_CSS: false
+          # TODO 211003 returns false positive: {"line":"                    <li><a href=\"https://www.linkedin.com/company/MYCMSPROJECTSPECIFIC\" title=\"{=\"MYCMSPROJECTSPECIFIC na LinkedIn\"|translate}\"><i class=\"fa fa-linkedin\" aria-hidden=\"true\"></i></a></li>","lineNumber":56,"offender":"linkedin.com/company/MYCMSPROJECTSPECIFIC","offenderEntropy":-1,"commit":"","repo":"","repoURL":"","leakURL":"","rule":"LinkedIn Secret Key","commitMessage":"","author":"","email":"","file":".","date":"0001-01-01T00:00:00Z","tags":"secret, LinkedIn"}
+          VALIDATE_GITLEAKS: false
           # TODO VALIDATE_JSCPD later
           VALIDATE_JSCPD: false
           # PHPStan run in matrix strategy in php-composer-phpunit.yml

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -157,6 +157,7 @@ jobs:
         cd dist
         # Only phpstan/phpstan-webmozart-assert + phpstan/phpstan added
         composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
+        composer require --dev rector/rector --prefer-dist --no-progress
         cd ..
     - name: "PHPStan webmozart-assert (app)"
       if: ${{ matrix.php-version >= '7.1' }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ log/*
 /cache/
 .sass-cache/
 /.php_cs.cache
+/.php-cs-fixer.cache
 
 #disable private local files
 *.local.php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### `Added` for new features
-- dist: build.sh: if not exists create conf/config.local.php + phinx.yml
+- dist/build.sh: if not exists create conf/config.local.php + phinx.yml
 
 ### `Changed` for changes in existing functionality
-- dist: VALIDATE_GITLEAKS: false because of false positive 
+- dist: VALIDATE_GITLEAKS: false because of false positive
 
 ### `Deprecated` for soon-to-be removed features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.4] - 2021-10-04
 
 - fixed MyTableLister::view ternary operator blocking non-empty table output
-- faster dist seed app creatin (rector.php + build.sh)
+- faster dist seed app creation (rector.php + build.sh)
 
 ### Added
 - dist/build.sh: if not exists create conf/config.local.php + phinx.yml
@@ -323,7 +323,8 @@ to
 
 
 
-[Unreleased]: https://github.com/WorkOfStan/mycms/compare/v0.4.3...HEAD
+[Unreleased]: https://github.com/WorkOfStan/mycms/compare/v0.4.4...HEAD
+[0.4.4]: https://github.com/WorkOfStan/mycms/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/WorkOfStan/mycms/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/WorkOfStan/mycms/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/WorkOfStan/mycms/compare/v0.4.0...v0.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### `Added` for new features
-- dist/build.sh: if not exists create conf/config.local.php + phinx.yml
 
 ### `Changed` for changes in existing functionality
-- dist: VALIDATE_GITLEAKS: false because of false positive
 
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features
 
 ### `Fixed` for any bug fixes
-- MyTableLister::view ternary operator blocking non-empty table output
-- dist: github online composer require --dev rector/rector
 
 ### `Security` in case of vulnerabilities
+
+## [0.4.4] - 2021-10-04
+
+- fixed MyTableLister::view ternary operator blocking non-empty table output
+- faster dist seed app creatin (rector.php + build.sh)
+
+### Added
+- dist/build.sh: if not exists create conf/config.local.php + phinx.yml
+- Faster MyCMS dist deployment by rector.php (github online check include composer require --dev rector/rector)
+- dist/build.sh: if not exists create conf/config.local.php + phinx.yml
+
+### Changed
+- dist: VALIDATE_GITLEAKS: false because of false positive
+- change github/super-linter master -> main
+
+### Removed
+- VALIDATE_GITLEAKS: false because of false positive (todo reconsider later)
+- unnecessary `sql =` constructs removed
+
+### Fixed
+- MyTableLister::view ternary operator blocking non-empty table output
+- dist: github online composer require --dev rector/rector
+- dist/classes/TableAdmin.php - line 177: Parameter #2 $multiplier of function str_repeat expects int,  float|int<-1, max> given.
 
 ## [0.4.3] - 2021-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### `Added` for new features
+- dist: build.sh: if not exists create conf/config.local.php + phinx.yml
 
 ### `Changed` for changes in existing functionality
+- dist: VALIDATE_GITLEAKS: false because of false positive 
 
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features
 
 ### `Fixed` for any bug fixes
+- dist: github online composer require --dev rector/rector
 
 ### `Security` in case of vulnerabilities
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Removed` for now removed features
 
 ### `Fixed` for any bug fixes
+- MyTableLister::view ternary operator blocking non-empty table output
 - dist: github online composer require --dev rector/rector
 
 ### `Security` in case of vulnerabilities

--- a/README.md
+++ b/README.md
@@ -172,10 +172,11 @@ because MySQLi environment isn't prepared (yet) and HTTP requests to self can't 
 
 ### PHPStan
 
-Till PHP<7.1 is supported, `phpstan/phpstan-webmozart-assert` can't be required-dev in composer.json.
+Till PHP<7.1 is supported, neither `phpstan/phpstan-webmozart-assert` nor `rector/rector` can't be required-dev in composer.json.
 Therefore, to properly take into account Assert statements by PHPStan (relevant for level>6), do a temporary (i.e. without commiting it to repository)
 ```sh
 composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
+composer require --dev rector/rector --prefer-dist --no-progress
 ```
 and use [conf/phpstan.webmozart-assert.neon](conf/phpstan.webmozart-assert.neon) to allow for `phpstan --configuration=conf/phpstan.webmozart-assert.neon analyse . --memory-limit 300M`.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Apache modules `mod_alias` (for hiding non-public files) and `mod_rewrite` (for 
 
 Once [composer](https://getcomposer.org/) is installed, execute the following command in your project root to install this library:
 ```sh
-composer require workofstan/mycms:^0.4.2
+composer require workofstan/mycms:^0.4.4
 ```
 Most of library's classes use prefix `My`.
 To customize the project, create your own classes as children inheriting MyCMS' classes in the `./classes/` directory and name them without the initial `My` in its name.  

--- a/classes/MyTableAdmin.php
+++ b/classes/MyTableAdmin.php
@@ -166,7 +166,7 @@ class MyTableAdmin extends MyTableLister
         $comment = json_decode(isset($field['comment']) ? (string) $field['comment'] : '{}', true);
         Tools::setifnull($comment['display']);
         if (!is_null($field['type']) && $comment['display'] == 'option') {
-            $query = $this->dbms->queryStrictObject($sql = 'SELECT DISTINCT ' . Tools::escapeDbIdentifier($key)
+            $query = $this->dbms->queryStrictObject('SELECT DISTINCT ' . Tools::escapeDbIdentifier($key)
                 . ' FROM ' . Tools::escapeDbIdentifier($this->table) . ' ORDER BY ' . Tools::escapeDbIdentifier($key) . ' LIMIT ' . $this->DEFAULTS['MAXSELECTSIZE']);
             $input = '<select name="fields[' . Tools::h($key) . ']" id="' . Tools::h($key . $this->rand) . '" class="form-control d-inline-block w-initial"'
                 . (isset($comment['display-own']) && $comment['display-own'] ? ' onchange="$(\'#' . Tools::h($key . $this->rand) . '_\').val(null)"' : '') . '>'
@@ -591,7 +591,7 @@ class MyTableAdmin extends MyTableLister
                             $value = null;
                         }
                         $sql .= ',' . Tools::escapeDbIdentifier($key) . '='
-                            . (is_null($value) ? 'NULL' : ($field['basictype'] == 'integer' ? (int) $value : (double) $value));
+                            . (is_null($value) ? 'NULL' : ($field['basictype'] == 'integer' ? (int) $value : (float) $value));
                         break;
                     default:
                         $sql .= ',' . Tools::escapeDbIdentifier($key) . '='

--- a/classes/MyTableLister.php
+++ b/classes/MyTableLister.php
@@ -324,10 +324,10 @@ class MyTableLister
                 case '+':
                 case '-':
                 case '*':
-                    $result .= ', ' . $this->escapeDbIdentifier($field) . ' = ' . $this->escapeDbIdentifier($field) . $vars['op'][$field] . ' ' . ($vars['op'][$field] == '*' ? (double) $value : (int) $value);
+                    $result .= ', ' . $this->escapeDbIdentifier($field) . ' = ' . $this->escapeDbIdentifier($field) . $vars['op'][$field] . ' ' . ($vars['op'][$field] == '*' ? (float) $value : (int) $value);
                     break;
                 case 'random':
-                    $result .= ', ' . $this->escapeDbIdentifier($field) . ' = RAND() * ' . ($value == 0 ? 1 : (double) $value);
+                    $result .= ', ' . $this->escapeDbIdentifier($field) . ' = RAND() * ' . ($value == 0 ? 1 : (float) $value);
                     break;
                 case 'now':
                 case 'uuid':
@@ -426,9 +426,9 @@ class MyTableLister
             $output .= $this->viewTable($query, $columns, $options)
                 . $this->pagination($sql['limit'], $options['total-rows'], null, $options);
         }
-        return $output . (!$options['total-rows'] && isset($_GET['col'])) ?
+        return $output . ((!$options['total-rows'] && isset($_GET['col'])) ?
             ('<p class="alert alert-danger"><small>' . $this->translate('No records found.') . '</small></p>') :
-            ('<p class="text-info"><small>' . $this->translate('Total rows: ') . $options['total-rows'] . '.</small></p>');
+            ('<p class="text-info"><small>' . $this->translate('Total rows: ') . $options['total-rows'] . '.</small></p>'));
     }
 
     /**

--- a/dist/.github/linters/phpcs.xml
+++ b/dist/.github/linters/phpcs.xml
@@ -19,6 +19,5 @@
         <exclude-pattern>db/migrations/*.php</exclude-pattern>
         <!-- TODO Ignore `Line exceeds 120 characters` until fixed -->
         <exclude-pattern>classes/AdminProcess.php</exclude-pattern>
-        <!-- obsoleted exclude-pattern>classes/TableAdmin.php</exclude-pattern -->
     </rule>
 </ruleset>

--- a/dist/.github/linters/phpcs.xml
+++ b/dist/.github/linters/phpcs.xml
@@ -19,6 +19,6 @@
         <exclude-pattern>db/migrations/*.php</exclude-pattern>
         <!-- TODO Ignore `Line exceeds 120 characters` until fixed -->
         <exclude-pattern>classes/AdminProcess.php</exclude-pattern>
-        <exclude-pattern>classes/TableAdmin.php</exclude-pattern>
+        <!-- obsoleted exclude-pattern>classes/TableAdmin.php</exclude-pattern -->
     </rule>
 </ruleset>

--- a/dist/.github/linters/phpcs.xml
+++ b/dist/.github/linters/phpcs.xml
@@ -17,5 +17,8 @@
     <rule ref="Generic.Files.LineLength">
         <!-- Don't apply `Line exceeds 120 characters` to SQL defining files -->
         <exclude-pattern>db/migrations/*.php</exclude-pattern>
+        <!-- TODO Ignore `Line exceeds 120 characters` until fixed -->
+        <exclude-pattern>classes/AdminProcess.php</exclude-pattern>
+        <exclude-pattern>classes/TableAdmin.php</exclude-pattern>
     </rule>
 </ruleset>

--- a/dist/.github/workflows/linter.yml
+++ b/dist/.github/workflows/linter.yml
@@ -19,6 +19,11 @@ on:
       # notest branches to ignore testing of partial online commits
       - 'notest/**'
 
+  pull_request:
+    branches-ignore:
+      # notest branches to ignore testing of partial online commits
+      - 'notest/**'
+
 ###############
 # Set the Job #
 ###############
@@ -54,6 +59,8 @@ jobs:
           VALIDATE_JAVASCRIPT_STANDARD: false
           VALIDATE_ANSIBLE: false
           VALIDATE_CSS: false
+          # TODO VALIDATE_JSCPD later
+          VALIDATE_JSCPD: false
           # PHPStan run in matrix strategy in php-composer-phpunit.yml
           VALIDATE_PHP_PHPSTAN: false
           VALIDATE_PHP_PSALM: false

--- a/dist/.github/workflows/linter.yml
+++ b/dist/.github/workflows/linter.yml
@@ -50,7 +50,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@master
+        uses: github/super-linter@main
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: develop

--- a/dist/.github/workflows/linter.yml
+++ b/dist/.github/workflows/linter.yml
@@ -59,6 +59,8 @@ jobs:
           VALIDATE_JAVASCRIPT_STANDARD: false
           VALIDATE_ANSIBLE: false
           VALIDATE_CSS: false
+          # TODO 211003 returns false positive: {"line":"                    <li><a href=\"https://www.linkedin.com/company/MYCMSPROJECTSPECIFIC\" title=\"{=\"MYCMSPROJECTSPECIFIC na LinkedIn\"|translate}\"><i class=\"fa fa-linkedin\" aria-hidden=\"true\"></i></a></li>","lineNumber":56,"offender":"linkedin.com/company/MYCMSPROJECTSPECIFIC","offenderEntropy":-1,"commit":"","repo":"","repoURL":"","leakURL":"","rule":"LinkedIn Secret Key","commitMessage":"","author":"","email":"","file":".","date":"0001-01-01T00:00:00Z","tags":"secret, LinkedIn"}
+          VALIDATE_GITLEAKS: false
           # TODO VALIDATE_JSCPD later
           VALIDATE_JSCPD: false
           # PHPStan run in matrix strategy in php-composer-phpunit.yml

--- a/dist/.github/workflows/php-composer-dependencies.yml
+++ b/dist/.github/workflows/php-composer-dependencies.yml
@@ -111,7 +111,7 @@ jobs:
       if: ${{ matrix.php-version >= '7.1' && steps.vendor-cache.outputs.cache-hit != 'true' }}
       run: |
         composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
-        composer require --dev rector/rector --prefer-dist --no-progress
+        #composer require --dev rector/rector --prefer-dist --no-progress
     - name: "PHPStan webmozart-assert"
       if: ${{ matrix.php-version >= '7.1' }}
       run: phpstan --configuration=conf/phpstan.webmozart-assert.neon analyse --no-interaction --no-progress .

--- a/dist/.github/workflows/php-composer-dependencies.yml
+++ b/dist/.github/workflows/php-composer-dependencies.yml
@@ -107,13 +107,9 @@ jobs:
     #   run: composer run-script test
 
     # PHPStan works for PHP/7.1+ so it can't even be in composer.json
-    - name: "Composer + PHPStan"
+    - name: "Composer phpstan-webmozart-assert"
+      if: ${{ matrix.php-version >= '7.1' && steps.vendor-cache.outputs.cache-hit != 'true' }}
+      run: composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
+    - name: "PHPStan webmozart-assert"
       if: ${{ matrix.php-version >= '7.1' }}
-      run: |
-        #to fix `Constant DB_USERNAME not found.` etc
-        #cp -p conf/config.local.dist.php conf/config.local.php
-        #composer update --prefer-dist --no-progress
-        phpstan analyse --no-interaction --no-progress .
-        # or ?
-        #composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
-        #phpstan --configuration=conf/phpstan.webmozart-assert.neon analyse --no-interaction --no-progress .
+      run: phpstan --configuration=conf/phpstan.webmozart-assert.neon analyse --no-interaction --no-progress .

--- a/dist/.github/workflows/php-composer-dependencies.yml
+++ b/dist/.github/workflows/php-composer-dependencies.yml
@@ -109,7 +109,9 @@ jobs:
     # PHPStan works for PHP/7.1+ so it can't even be in composer.json
     - name: "Composer phpstan-webmozart-assert"
       if: ${{ matrix.php-version >= '7.1' && steps.vendor-cache.outputs.cache-hit != 'true' }}
-      run: composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
+      run: |
+        composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
+        composer require --dev rector/rector --prefer-dist --no-progress
     - name: "PHPStan webmozart-assert"
       if: ${{ matrix.php-version >= '7.1' }}
       run: phpstan --configuration=conf/phpstan.webmozart-assert.neon analyse --no-interaction --no-progress .

--- a/dist/.gitignore
+++ b/dist/.gitignore
@@ -9,6 +9,7 @@ cache/*
 !/cache/.htaccess
 .sass-cache/
 /.php_cs.cache
+/.php-cs-fixer.cache
 
 #disable private local files
 *.local.php

--- a/dist/CHANGELOG.md
+++ b/dist/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Security` in case of vulnerabilities
 
 ## [0.1] - YYYY-MM-DD
-- new application based on MyCMS/0.4.3/dist
+- new application based on MyCMS/0.4.4/dist
 
 [Unreleased]: https://github.com/vendor/project/compare/v0.1...HEAD
 [0.1]: https://github.com/vendor/project/releases/tag/v0.1

--- a/dist/README.md
+++ b/dist/README.md
@@ -330,7 +330,7 @@ That's how it works and how to set an API:
 ## Coding style and linting
 
 GitHub Actions run PHPSTAN to identify errors
-* the same way as would be run locally
+* the same way as run locally
 * so it might need to know which global constants are used (`.github/linters/conf/constants.php`) on top of standard config files
 * and where to look for present classes (scanDirectories), hence following files:
 * `phpstan.neon.dist` - for PHPSTAN of this app (dist folder)
@@ -408,7 +408,6 @@ Feature flag is propagated to Class Admin, Controller, to JS and to Latte.
 * 200712: update bootstrap <https://getbootstrap.com/> incl. map --> admin.php expects section
 * 200712: update jquery <https://jquery.com/> incl. map --> admin.php expects section
 * 200712: update fontawesome --> admin.php expects section
-* 200712: remove unnecessary `sql =` constructs
 * 200802: test with 2 categories
 * 200802: image for product and category in assets
 * 200921: (MyCMS) properly fix message: '#Parameter #2 $newvalue of function ini_set expects string, true given.#'    path: /github/workspace/set-environment.php

--- a/dist/README.md
+++ b/dist/README.md
@@ -45,7 +45,7 @@ script/autotrack.V.V.V.js and script/autotrack.V.V.V.js.map are manually taken f
 
 ## MyCMS dist deployment
 * Folder `/dist` contains initial *distribution* files for a new project using MyCMS, therefore copy it to your new project folder.
-* Replace the string `mycmsprojectnamespace` with your project namespace.
+* Replace the string `mycmsprojectnamespace` with your project namespace in composer.json and BY RUNNING `vendor/bin/rector process --dry-run` (of course before you have to `composer require rector/rector --dev` and after remove `--dry-run`).
 * Replace the string `MYCMSPROJECTSPECIFIC` with other website specific information (Brand, Twitter address, phone number, database name, name of icon in manifest.json etc.).
 * Default *admin.php* credentials are *john* / *Ew7Ri561*   - MUST be deleted after the real admin account is set up.
 * Change `define('MYCMS_SECRET', 'u7-r!!T7.&&7y6ru');` //16-byte random string, unique per project in `conf/config.php`

--- a/dist/Test/FaviconTest.php
+++ b/dist/Test/FaviconTest.php
@@ -9,7 +9,6 @@ require_once __DIR__ . '/../conf/config.php';
 
 class FaviconTest extends \PHPUnit_Framework_TestCase
 {
-
     /** @var Backyard */
     protected $backyard;
 
@@ -105,7 +104,8 @@ class FaviconTest extends \PHPUnit_Framework_TestCase
             $this->assertNotFalse(is_array($result), "cURL failed on {$url} with result=" . print_r($result, true));
             $this->assertFalse(
                 ($result['HTTP_CODE'] === 0),
-                "URL {$url} is not available. (Is \$backyardConf['web_address'] properly configured?)"
+                "URL {$url} is not available. "
+                . "(Are \$backyardConf['web_domain'] and \$backyardConf['web_path'] properly configured?)"
             );
             $this->assertEquals(
                 200,

--- a/dist/build.sh
+++ b/dist/build.sh
@@ -4,6 +4,12 @@ echo "To work on low performing environments, the script accepts number of secon
 paramSleepSec=0
 [ "$1" ] && [ "$1" -ge 0 ] && paramSleepSec=$1
 
+if [[ ! -f "conf/config.local.dist.php" || ! -f "phinx.yml" ]]; then
+    [ ! -f "conf/config.local.php" ] && cp -p conf/config.local.dist.php conf/config.local.php && echo "Check the newly created conf/config.local.php"
+    [ ! -f "phinx.yml" ] && cp -p phinx.dist.yml phinx.yml && echo "Check the newly created phinx.yml"
+    exit 0
+fi
+
 composer update -a --prefer-dist --no-progress
 sleep "$paramSleepSec"s
 vendor/bin/phinx migrate -e development

--- a/dist/classes/MyCMSProject.php
+++ b/dist/classes/MyCMSProject.php
@@ -67,11 +67,13 @@ class MyCMSProject extends MyCMS
                 Utils::jsonOrEcho($this->context['json'], $directJsonCall, $backyard);
             }
         } elseif (array_key_exists('messageFailure', $this->context) && !is_null($this->context['messageFailure'])) {
+            Debugger::barDump('contextJson is expected to be an array');
             // TODO remove after Controller.php refactor all context['message... to    Tools::addMessage('error',
             Tools::addMessage('error', $this->context['messageFailure']);
             header('HTTP/1.1 404 Not Found', true, 404);
             echo($this->context['messageFailure']);
         } else {
+            Debugger::barDump('contextJson is expected to be an array');
             header('HTTP/1.1 404 Not Found', true, 404);
         }
 

--- a/dist/classes/ProjectSpecific.php
+++ b/dist/classes/ProjectSpecific.php
@@ -153,7 +153,7 @@ class ProjectSpecific extends ProjectCommon
         $options += array('path' => $result['path'], 'except_id' => $result['id']);
         if (($pos = strpos($result['description'], '%CHILDREN%')) !== false) {
             $result['description'] = str_replace('%CHILDREN%', '', $result['description']);
-            $this->MyCMS->context['children'] = ProjectSpecific::getChildren($result['category_id'], $options);
+            $this->MyCMS->context['children'] = self::getChildren($result['category_id'], $options);
         }/* elseif (($pos = strpos($result['description'], '%GRANDCHILDREN%')) !== false) {
           $result['description'] = str_replace('%GRANDCHILDREN%', '', $result['description']);
           $this->MyCMS->context['children'] = ProjectSpecific::getChildren(
@@ -162,7 +162,7 @@ class ProjectSpecific extends ProjectCommon
         if (($pos = strpos($result['description'], '%SITEMAP%')) !== false) {
             $result['description'] = str_replace(
                 '%SITEMAP%',
-                ProjectSpecific::getSitemap($options), // TOOD use self:: instead of ProjectSpecific
+                self::getSitemap($options),
                 $result['description']
             );
         }

--- a/dist/classes/ProjectSpecific.php
+++ b/dist/classes/ProjectSpecific.php
@@ -264,7 +264,7 @@ class ProjectSpecific extends ProjectCommon
     {
         Tools::setifnotset($options['level'], 0);
         if ($options['level'] && Tools::nonzero($options['path'])) {
-            $tempKeys = $this->MyCMS->fetchAndReindex($sql = 'SELECT id FROM ' . TAB_PREFIX . 'category
+            $tempKeys = $this->MyCMS->fetchAndReindex('SELECT id FROM ' . TAB_PREFIX . 'category
                 WHERE LEFT(path, ' . strlen($options['path']) . ')="' . $this->MyCMS->escapeSQL($options['path']) . '"
                 AND LENGTH(path) > ' . strlen($options['path']) . '
                 AND LENGTH(path) <= ' . (strlen($options['path']) + (int) $options['level'] * PATH_MODULE));

--- a/dist/classes/TableAdmin.php
+++ b/dist/classes/TableAdmin.php
@@ -98,9 +98,16 @@ class TableAdmin extends MyTableAdmin
             case "content\\image":
             case "product\\image":
                 $result = '<div class="input-group">'
-                    . Tools::htmlInput("fields[$field]", '', $value, ['class' => 'form-control input-image', 'id' => $field . $this->rand])
+                    . Tools::htmlInput(
+                        "fields[$field]",
+                        '',
+                        $value,
+                        ['class' => 'form-control input-image', 'id' => $field . $this->rand]
+                    )
                     . '<span class="input-group-btn">'
-                    . '<button type="button" class="btn btn-secondary ImageSelector" data-target="#' . Tools::h($field . $this->rand) . '" title="' . $this->translate('Select') . '"><i class="fa fa-image" aria-hidden="true"></i></button>'
+                    . '<button type="button" class="btn btn-secondary ImageSelector" data-target="#'
+                    . Tools::h($field . $this->rand) . '" title="' . $this->translate('Select')
+                    . '"><i class="fa fa-image" aria-hidden="true"></i></button>'
                     . '</span></div>';
                 break;
 
@@ -110,11 +117,17 @@ class TableAdmin extends MyTableAdmin
                 $result = $this->translate('Parent category') . ':<br />'
                     . Tools::htmlInput('path-original', '', $value, 'hidden')
                     . '<select class="form-control" name="path-parent" id="path' . $this->rand . '"><option />';
-                $rows = $this->dbms->fetchAll('SELECT path,category_' . $_SESSION['language'] . ' AS category FROM ' . TAB_PREFIX . 'category ORDER BY path');
+                $rows = $this->dbms->fetchAll('SELECT path,category_' . $_SESSION['language'] . ' AS category FROM '
+                    . TAB_PREFIX . 'category ORDER BY path');
                 $tmp = substr($value, 0, -PATH_MODULE);
                 if (is_array($rows)) {
                     foreach ($rows as $row) {
-                        $result .= Tools::htmlOption($row['path'], str_repeat('… ', max(strlen($row['path']) / PATH_MODULE - 1, 0)) . $row['category'], $tmp, Tools::begins($row['path'], $value));
+                        $result .= Tools::htmlOption(
+                            $row['path'],
+                            str_repeat('… ', (int) max(strlen($row['path']) / PATH_MODULE - 1, 0)) . $row['category'],
+                            $tmp,
+                            Tools::begins($row['path'], $value)
+                        );
                     }
                 }
                 $result .= '</select>';
@@ -123,13 +136,17 @@ class TableAdmin extends MyTableAdmin
             // Selection list of relations to product
             // TODO try this template in dist
             case "content\\product_id":
-                $result = '<select class="form-control" name="fields[product_id]" id="' . $field . $this->rand . '"><option />';
-                $rows = $this->dbms->fetchAll('SELECT p.id,category_' . $_SESSION['language'] . ' AS category,product_' . $_SESSION['language'] . ' AS title FROM ' . TAB_PREFIX . 'product p LEFT JOIN ' . TAB_PREFIX . 'category c ON p.category_id = c.id ORDER BY c.path,p.sort');
+                $result = '<select class="form-control" name="fields[product_id]" id="' . $field . $this->rand
+                    . '"><option />';
+                $rows = $this->dbms->fetchAll('SELECT p.id,category_' . $_SESSION['language'] . ' AS category,product_'
+                    . $_SESSION['language'] . ' AS title FROM ' . TAB_PREFIX . 'product p LEFT JOIN '
+                    . TAB_PREFIX . 'category c ON p.category_id = c.id ORDER BY c.path,p.sort');
                 if (is_array($rows)) {
                     $tmp = null;
                     foreach ($rows as $row) {
                         if ($tmp != $row['category']) {
-                            $result .= (is_null($tmp) ? '' : '</optgroup>') . '<optgroup label="' . Tools::h($tmp = $row['category']) . '">' . PHP_EOL;
+                            $result .= (is_null($tmp) ? '' : '</optgroup>') . '<optgroup label="'
+                                . Tools::h($tmp = $row['category']) . '">' . PHP_EOL;
                         }
                         $result .= Tools::htmlOption($row['id'], $row['title'], $value) . PHP_EOL;
                     }

--- a/dist/classes/TableAdmin.php
+++ b/dist/classes/TableAdmin.php
@@ -119,13 +119,12 @@ class TableAdmin extends MyTableAdmin
                     . '<select class="form-control" name="path-parent" id="path' . $this->rand . '"><option />';
                 $rows = $this->dbms->fetchAll('SELECT path,category_' . $_SESSION['language'] . ' AS category FROM '
                     . TAB_PREFIX . 'category ORDER BY path');
-                $tmp = substr($value, 0, -PATH_MODULE);
                 if (is_array($rows)) {
                     foreach ($rows as $row) {
                         $result .= Tools::htmlOption(
                             $row['path'],
                             str_repeat('… ', (int) max(strlen($row['path']) / PATH_MODULE - 1, 0)) . $row['category'],
-                            $tmp,
+                            substr($value, 0, -PATH_MODULE),
                             Tools::begins($row['path'], $value)
                         );
                     }

--- a/dist/permissions.sh
+++ b/dist/permissions.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# TODO - if !exists phinx.yml & conf/config.local.php - create them by copying
+
+# directories where www-data MUST have permission to write
+chmod g+w cache
+chmod g+w log
+#chmod g+w api/*/log
+
+# legacy files in those directories MUST have the right permissions in order to be writable (No legacy files: chmod: cannot access 'cache/*' ...)
+chmod 660 cache/*
+chmod 660 log/*
+#chmod 660 api/*/log/*

--- a/dist/permissions.sh
+++ b/dist/permissions.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# TODO - if !exists phinx.yml & conf/config.local.php - create them by copying
+# Note: build.sh is used to create if !exists phinx.yml & conf/config.local.php
 
 # directories where www-data MUST have permission to write
 chmod g+w cache

--- a/dist/rector.php
+++ b/dist/rector.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+//use Rector\Php74\Rector\Property\TypedPropertyRector;
+use Rector\Renaming\Rector\Namespace_\RenameNamespaceRector;
+//use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+/**
+ * @phpstan-ignore-next-line
+ */
+return static function (ContainerConfigurator $containerConfigurator): void {
+    // get parameters
+    /**
+     * @phpstan-ignore-next-line
+     */
+    $parameters = $containerConfigurator->parameters();
+
+    // paths to refactor; solid alternative to CLI arguments
+    $parameters->set(
+        Option::PATHS,
+        [
+            __DIR__ . '/*.php',
+            __DIR__ . '/api',
+            __DIR__ . '/classes',
+            __DIR__ . '/Test'
+        ]
+    );
+
+    // Define what rule sets will be applied
+    //$containerConfigurator->import(SetList::DEAD_CODE);
+    //
+    // get services (needed for register a single rule)
+    /**
+     * @phpstan-ignore-next-line
+     */
+    $services = $containerConfigurator->services();
+
+    // register a single rule
+    // $services->set(TypedPropertyRector::class);
+    //
+    // RENAME TO THE APP NAMESPACE
+    $services->set(RenameNamespaceRector::class)
+        ->call('configure', [[
+            RenameNamespaceRector::OLD_TO_NEW_NAMESPACES => [
+                'WorkOfStan\mycmsprojectnamespace' => 'WorkOfStan\YourRepoName',
+            ],]]);
+    //TODO: fix unnecessary long object names, such as `new \WorkOfStan\YourRepoName\ProjectSpecific`
+    //when `use WorkOfStan\YourRepoName\ProjectSpecific;` was used
+};

--- a/dist/rector.php
+++ b/dist/rector.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * Rector configuration as proposed at https://github.com/rectorphp/rector
+ */
+
 declare(strict_types=1);
 
 use Rector\Core\Configuration\Option;


### PR DESCRIPTION
- fixed MyTableLister::view ternary operator blocking non-empty table output
- faster dist seed app creation (rector.php + build.sh)

### Added
- dist/build.sh: if not exists create conf/config.local.php + phinx.yml
- Faster MyCMS dist deployment by rector.php (github online check include composer require --dev rector/rector)
- dist/build.sh: if not exists create conf/config.local.php + phinx.yml

### Changed
- dist: VALIDATE_GITLEAKS: false because of false positive
- change github/super-linter master -> main

### Removed
- VALIDATE_GITLEAKS: false because of false positive (todo reconsider later)
- unnecessary `sql =` constructs removed

### Fixed
- MyTableLister::view ternary operator blocking non-empty table output
- dist: github online composer require --dev rector/rector
- dist/classes/TableAdmin.php - line 177: Parameter 2 $multiplier of function str_repeat expects int,  float|int<-1, max> given.