### PR TITLE
Nested array type hints added

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -53,7 +53,7 @@ jobs:
         uses: github/super-linter@main
         env:
           VALIDATE_ALL_CODEBASE: true
-          DEFAULT_BRANCH: develop
+          DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JAVASCRIPT_ES_CONFIG_FILE: .eslintrc.yml
           VALIDATE_JAVASCRIPT_STANDARD: false

--- a/.github/workflows/php-composer-dependencies-reusable.yml
+++ b/.github/workflows/php-composer-dependencies-reusable.yml
@@ -107,7 +107,7 @@ jobs:
       if: ${{ matrix.php-version >= '7.1' && steps.vendor-cache.outputs.cache-hit != 'true' }}
       run: |
         composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
-        composer require --dev rector/rector --prefer-dist --no-progress
+        #todo return when rector ready for phpstan:1.0#composer require --dev rector/rector --prefer-dist --no-progress
     - name: "PHPStan webmozart-assert"
       if: ${{ matrix.php-version >= '7.1' }}
       run: phpstan --configuration=conf/phpstan.webmozart-assert.neon analyse --no-interaction --no-progress .

--- a/.github/workflows/php-composer-dependencies-reusable.yml
+++ b/.github/workflows/php-composer-dependencies-reusable.yml
@@ -106,7 +106,7 @@ jobs:
     - name: "Composer phpstan-webmozart-assert"
       if: ${{ matrix.php-version >= '7.1' && steps.vendor-cache.outputs.cache-hit != 'true' }}
       run: |
-        composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
+        composer require --dev phpstan/phpstan-webmozart-assert:^0.12 --prefer-dist --no-progress
         composer require --dev rector/rector --prefer-dist --no-progress
     - name: "PHPStan webmozart-assert"
       if: ${{ matrix.php-version >= '7.1' }}

--- a/.github/workflows/php-composer-dependencies-reusable.yml
+++ b/.github/workflows/php-composer-dependencies-reusable.yml
@@ -106,7 +106,7 @@ jobs:
     - name: "Composer phpstan-webmozart-assert"
       if: ${{ matrix.php-version >= '7.1' && steps.vendor-cache.outputs.cache-hit != 'true' }}
       run: |
-        composer require --dev phpstan/phpstan-webmozart-assert:^0.12 --prefer-dist --no-progress
+        composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
         composer require --dev rector/rector --prefer-dist --no-progress
     - name: "PHPStan webmozart-assert"
       if: ${{ matrix.php-version >= '7.1' }}

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -156,8 +156,7 @@ jobs:
       run: |
         cd dist
         # Only phpstan/phpstan-webmozart-assert + phpstan/phpstan added
-        #composer require --dev phpstan/phpstan-phpunit:^0.12 --prefer-dist --no-progress
-        composer require --dev phpstan/phpstan-webmozart-assert:^0.12 --prefer-dist --no-progress
+        composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
         composer require --dev rector/rector --prefer-dist --no-progress
         cd ..
     - name: "PHPStan webmozart-assert (app)"

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -172,7 +172,7 @@ jobs:
       if: ${{ matrix.php-version >= '7.1' && steps.vendor-cache.outputs.cache-hit != 'true' }}
       run: |
         # Only phpstan/phpstan-webmozart-assert + phpstan/phpstan added
-        composer require --dev phpstan/phpstan-webmozart-assert:^0.12 --prefer-dist --no-progress
+        composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
     - name: "PHPStan webmozart-assert (library + app)"
       # alternative syntax # if: ${{ matrix.php-version != '5.3' && matrix.php-version != '5.6' }}
       if: ${{ matrix.php-version >= '7.1' }}

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -156,7 +156,7 @@ jobs:
       run: |
         cd dist
         # Only phpstan/phpstan-webmozart-assert + phpstan/phpstan added
-        composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
+        composer require --dev phpstan/phpstan-webmozart-assert:^0.12 --prefer-dist --no-progress
         composer require --dev rector/rector --prefer-dist --no-progress
         cd ..
     - name: "PHPStan webmozart-assert (app)"

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -156,8 +156,8 @@ jobs:
       run: |
         cd dist
         # Only phpstan/phpstan-webmozart-assert + phpstan/phpstan added
+        composer require --dev phpstan/phpstan-phpunit:^0.12 --prefer-dist --no-progress        
         composer require --dev phpstan/phpstan-webmozart-assert:^0.12 --prefer-dist --no-progress
-        composer require --dev phpstan/phpstan-phpunit:^0.12 --prefer-dist --no-progress
         composer require --dev rector/rector --prefer-dist --no-progress
         cd ..
     - name: "PHPStan webmozart-assert (app)"
@@ -172,7 +172,7 @@ jobs:
       if: ${{ matrix.php-version >= '7.1' && steps.vendor-cache.outputs.cache-hit != 'true' }}
       run: |
         # Only phpstan/phpstan-webmozart-assert + phpstan/phpstan added
-        composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
+        composer require --dev phpstan/phpstan-webmozart-assert:^0.12 --prefer-dist --no-progress
     - name: "PHPStan webmozart-assert (library + app)"
       # alternative syntax # if: ${{ matrix.php-version != '5.3' && matrix.php-version != '5.6' }}
       if: ${{ matrix.php-version >= '7.1' }}

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -157,6 +157,7 @@ jobs:
         cd dist
         # Only phpstan/phpstan-webmozart-assert + phpstan/phpstan added
         composer require --dev phpstan/phpstan-webmozart-assert:^0.12 --prefer-dist --no-progress
+        composer require --dev phpstan/phpstan-phpunit --prefer-dist --no-progress
         composer require --dev rector/rector --prefer-dist --no-progress
         cd ..
     - name: "PHPStan webmozart-assert (app)"

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -157,7 +157,7 @@ jobs:
         cd dist
         # Only phpstan/phpstan-webmozart-assert + phpstan/phpstan added
         composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
-        composer require --dev rector/rector --prefer-dist --no-progress
+        #todo return when rector ready for phpstan:1.0#composer require --dev rector/rector --prefer-dist --no-progress
         cd ..
     - name: "PHPStan webmozart-assert (app)"
       if: ${{ matrix.php-version >= '7.1' }}

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -157,7 +157,7 @@ jobs:
         cd dist
         # Only phpstan/phpstan-webmozart-assert + phpstan/phpstan added
         composer require --dev phpstan/phpstan-webmozart-assert:^0.12 --prefer-dist --no-progress
-        composer require --dev phpstan/phpstan-phpunit --prefer-dist --no-progress
+        composer require --dev phpstan/phpstan-phpunit:^0.12 --prefer-dist --no-progress
         composer require --dev rector/rector --prefer-dist --no-progress
         cd ..
     - name: "PHPStan webmozart-assert (app)"

--- a/.github/workflows/php-composer-phpunit.yml
+++ b/.github/workflows/php-composer-phpunit.yml
@@ -156,7 +156,7 @@ jobs:
       run: |
         cd dist
         # Only phpstan/phpstan-webmozart-assert + phpstan/phpstan added
-        composer require --dev phpstan/phpstan-phpunit:^0.12 --prefer-dist --no-progress        
+        #composer require --dev phpstan/phpstan-phpunit:^0.12 --prefer-dist --no-progress
         composer require --dev phpstan/phpstan-webmozart-assert:^0.12 --prefer-dist --no-progress
         composer require --dev rector/rector --prefer-dist --no-progress
         cd ..

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features
+- github automated test rector/rector (todo return when rector ready for phpstan:1.0)
 
 ### `Fixed` for any bug fixes
 - some type hint imperfections (especially for nested arrays) in [PHPStan level=8](https://github.com/phpstan/phpstan/releases/tag/1.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Removed` for now removed features
 
 ### `Fixed` for any bug fixes
-- some type hint imperfections (especially for recursive arrays) in PHPStan level=8
+- some type hint imperfections (especially for nested arrays) in [PHPStan level=8](https://github.com/phpstan/phpstan/releases/tag/1.0.0)
 
 ### `Security` in case of vulnerabilities
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### `Added` for new features
+- phpstan.sh and phpstan-remove.sh for local testing
+- phpstan-baseline.neon to hide type hint imperfections in PHPStan level=8 (TODO fix these)
 
 ### `Changed` for changes in existing functionality
 - instead of dist specific workflows, use reusable ones (linter.yml, overtrue-phplint.yml, php-composer-dependencies.yml, phpcbf.yml)
 - VALIDATE_GITHUB_ACTIONS: false as it returns false positive `unknown Webhook event "workflow_call"` (todo reconsider later)
+- PHPStan level lowered to 8 due to stricter PHPStan:1.0
 
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features
 
 ### `Fixed` for any bug fixes
+- some type hint imperfections (especially for recursive arrays) in PHPStan level=8
 
 ### `Security` in case of vulnerabilities
 

--- a/classes/LogMysqli.php
+++ b/classes/LogMysqli.php
@@ -96,7 +96,7 @@ class LogMysqli extends BackyardMysqli
      * If it is empty or database call fails, throws Exception.
      *
      * @param string $sql
-     * @return array[]
+     * @return array<array<mixed>>
      * @throws Exception
      */
     public function queryStrictNonEmptyArray($sql)
@@ -264,7 +264,7 @@ class LogMysqli extends BackyardMysqli
                 isset($fields[$column]['type']) &&
                 ($fields[$column]['type'] == 'set' || $fields[$column]['type'] == 'enum')
             ) {
-                $result .= "$escColumn - 0 AS $escColumn"; //NULLs will persist
+                $result .= "$escColumn - 0 AS $escColumn"; // NULLs will persist
             } else {
                 $result .= $escColumn;
             }
@@ -317,7 +317,7 @@ class LogMysqli extends BackyardMysqli
      * Execute an SQL, fetch and return all resulting rows
      *
      * @param string $sql
-     * @return array<array> array of associative arrays for each result row or empty array on error or no results
+     * @return array<array<mixed>> array of associative arrays for each result row or empty array on error or no results
      */
     public function fetchAll($sql)
     {
@@ -343,7 +343,7 @@ class LogMysqli extends BackyardMysqli
      *     [1=>[[name=>'John',surname=>'Doe'], [name=>'Mary',surname=>'Saint']], 2=>[...]]
      *
      * @param string $sql SQL statement to be executed
-     * @return array<array|string>|false - either associative array, empty array on empty SELECT, or false on error
+     * @return array<array<mixed>|string>|false - either associative array, empty array on empty SELECT, or false on error
      *   Error for this function is also an SQL statement that returns true.
      */
     public function fetchAndReindex($sql)

--- a/classes/LogMysqli.php
+++ b/classes/LogMysqli.php
@@ -343,7 +343,8 @@ class LogMysqli extends BackyardMysqli
      *     [1=>[[name=>'John',surname=>'Doe'], [name=>'Mary',surname=>'Saint']], 2=>[...]]
      *
      * @param string $sql SQL statement to be executed
-     * @return array<array<mixed>|string>|false - either associative array, empty array on empty SELECT, or false on error
+     * @return array<array<mixed>|string>|false
+     *   Result is either associative array, empty array on empty SELECT, or false on error
      *   Error for this function is also an SQL statement that returns true.
      */
     public function fetchAndReindex($sql)

--- a/classes/LogMysqli.php
+++ b/classes/LogMysqli.php
@@ -96,7 +96,7 @@ class LogMysqli extends BackyardMysqli
      * If it is empty or database call fails, throws Exception.
      *
      * @param string $sql
-     * @return array<array<mixed>>
+     * @return array<mixed>
      * @throws Exception
      */
     public function queryStrictNonEmptyArray($sql)

--- a/classes/MyAdmin.php
+++ b/classes/MyAdmin.php
@@ -19,7 +19,7 @@ class MyAdmin extends MyCommon
 {
     use \Nette\SmartObject;
 
-    /** @var array<array<bool>> */
+    /** @var array<array<mixed>> */
     protected $agendas = [];
 
     /** @var array<string> */

--- a/classes/MyAdmin.php
+++ b/classes/MyAdmin.php
@@ -19,13 +19,13 @@ class MyAdmin extends MyCommon
 {
     use \Nette\SmartObject;
 
-    /** @var array<array> */
+    /** @var array<array<bool>> */
     protected $agendas = [];
 
     /** @var array<string> */
     protected $ASSETS_SUBFOLDERS = [];
 
-    /** @var array<array> client-side resources - css, js, fonts etc. */
+    /** @var array<array<string>> client-side resources - css, js, fonts etc. */
     protected $clientSideResources = [
         'js' => [
             'scripts/jquery.js',

--- a/classes/MyCMS.php
+++ b/classes/MyCMS.php
@@ -33,7 +33,7 @@ class MyCMS extends MyCMSMonoLingual
     /**
      * PARAMETRIC URL into TEMPLATE conditions (for FriendlyURL functionality)
      *
-     * @var array<array>
+     * @var array<array<string|bool>>
      */
     public $templateAssignementParametricRules;
 

--- a/classes/MyCMSMonoLingual.php
+++ b/classes/MyCMSMonoLingual.php
@@ -135,7 +135,8 @@ class MyCMSMonoLingual
     /**
      *
      * @param string $sql SQL statement to be executed
-     * @return array<array<mixed>|string>|false - either associative array, empty array on empty SELECT, or false on error
+     * @return array<array<mixed>|string>|false
+     *   Returns either associative array, empty array on empty SELECT, or false on error
      */
     public function fetchAndReindex($sql)
     {

--- a/classes/MyCMSMonoLingual.php
+++ b/classes/MyCMSMonoLingual.php
@@ -125,7 +125,7 @@ class MyCMSMonoLingual
     /**
      *
      * @param string $sql
-     * @return array<array> array of associative arrays for each result row or empty array on error or no results
+     * @return array<array<mixed>> array of associative arrays for each result row or empty array on error or no results
      */
     public function fetchAll($sql)
     {
@@ -135,7 +135,7 @@ class MyCMSMonoLingual
     /**
      *
      * @param string $sql SQL statement to be executed
-     * @return array<array|string>|false - either associative array, empty array on empty SELECT, or false on error
+     * @return array<array<mixed>|string>|false - either associative array, empty array on empty SELECT, or false on error
      */
     public function fetchAndReindex($sql)
     {

--- a/classes/ThrowableFunctions/ThrowablePHPFunctions.php
+++ b/classes/ThrowableFunctions/ThrowablePHPFunctions.php
@@ -70,7 +70,7 @@ function glob($pattern, $flags = 0)
  *
  * @param mixed $value
  * @param int $flags
- * @param int $depth
+ * @param int<1, max> $depth
  * @return string
  */
 function json_encode($value, $flags = 0, $depth = 512)

--- a/conf/phpstan.common.neon
+++ b/conf/phpstan.common.neon
@@ -1,4 +1,4 @@
-# TODO fix these old imperfection
+# TODO fix these old imperfections
 includes:
       - ../phpstan-baseline.neon
 

--- a/conf/phpstan.common.neon
+++ b/conf/phpstan.common.neon
@@ -1,3 +1,7 @@
+# TODO fix these old imperfection
+includes:
+      - ../phpstan-baseline.neon
+
 parameters:
     excludePaths:
         analyse:

--- a/conf/phpstan.webmozart-assert.neon
+++ b/conf/phpstan.webmozart-assert.neon
@@ -5,3 +5,5 @@ includes:
       # to use https://github.com/phpstan/phpstan-webmozart-assert
       # phpstan/phpstan-webmozart-assert requires this settings
       - ../vendor/phpstan/phpstan-webmozart-assert/extension.neon
+      # Ignore errors in rector.php when rector/rector is not installed
+      - ../dist/conf/phpstan.rector.neon

--- a/conf/phpstan.webmozart-assert.neon
+++ b/conf/phpstan.webmozart-assert.neon
@@ -6,4 +6,4 @@ includes:
       # phpstan/phpstan-webmozart-assert requires this settings
       - ../vendor/phpstan/phpstan-webmozart-assert/extension.neon
       # Ignore errors in rector.php when rector/rector is not installed
-      - ../dist/conf/phpstan.rector.neon
+      #- ../dist/conf/phpstan.rector.neon

--- a/dist/Test/FriendlyUrlTest.php
+++ b/dist/Test/FriendlyUrlTest.php
@@ -107,8 +107,8 @@ class FriendlyUrlTest extends \PHPUnit_Framework_TestCase
             //(' session:' . http_build_query($friendlyUrlOptions['session'])) : '')
             . ' templateDetermined: ' . print_r($templateDetermined, true);
         if (FORCE_301 && FRIENDLY_URL) {
-            $this->assertIsArray(
-//                'array',
+            $this->assertInternalType(
+                'array',
                 $templateDetermined,
                 'MUST return array: Determine template ' . $message . ' but template=' . $this->myCms->template
             );

--- a/dist/Test/FriendlyUrlTest.php
+++ b/dist/Test/FriendlyUrlTest.php
@@ -720,6 +720,14 @@ class FriendlyUrlTest extends \PHPUnit_Framework_TestCase
     public function testPageStatusOverHttp()
     {
         $urlsToBeCheckedAny = [
+            // so that offsets 'allow_redirect', 'http_status' and 'is_json' can be isset() tested
+            [
+                'relative_url' => '', // home
+                // 'http_status' => 200,
+                'allow_redirect' => true,
+                // 'contains_text' => 'Lorem ipsum dolor sit amet',
+                // 'is_json' => false
+            ],
             [
                 'relative_url' => '', // home
                 'http_status' => 200,

--- a/dist/Test/FriendlyUrlTest.php
+++ b/dist/Test/FriendlyUrlTest.php
@@ -13,7 +13,6 @@ require_once __DIR__ . '/../conf/config.php';
 
 class FriendlyUrlTest extends \PHPUnit_Framework_TestCase
 {
-
     /** @var MyCMSProject */
     protected $myCms;
 
@@ -108,8 +107,8 @@ class FriendlyUrlTest extends \PHPUnit_Framework_TestCase
             //(' session:' . http_build_query($friendlyUrlOptions['session'])) : '')
             . ' templateDetermined: ' . print_r($templateDetermined, true);
         if (FORCE_301 && FRIENDLY_URL) {
-            $this->assertInternalType(
-                'array',
+            $this->assertIsArray(
+//                'array',
                 $templateDetermined,
                 'MUST return array: Determine template ' . $message . ' but template=' . $this->myCms->template
             );

--- a/dist/Test/FriendlyUrlTest.php
+++ b/dist/Test/FriendlyUrlTest.php
@@ -720,13 +720,10 @@ class FriendlyUrlTest extends \PHPUnit_Framework_TestCase
     public function testPageStatusOverHttp()
     {
         $urlsToBeCheckedAny = [
-            // so that offsets 'allow_redirect', 'http_status' and 'is_json' can be isset() tested
             [
+                // so that isset() test of offsets 'allow_redirect', 'http_status', 'is_json' allowed by PHPStan
                 'relative_url' => '', // home
-                // 'http_status' => 200,
-                // 'allow_redirect' => true,
-                'contains_text' => 'Lorem ipsum dolor sit amet',
-                // 'is_json' => false
+                'contains_text' => 'Lorem ipsum dolor sit amet'
             ],
             [
                 'relative_url' => '', // home

--- a/dist/Test/FriendlyUrlTest.php
+++ b/dist/Test/FriendlyUrlTest.php
@@ -724,8 +724,8 @@ class FriendlyUrlTest extends \PHPUnit_Framework_TestCase
             [
                 'relative_url' => '', // home
                 // 'http_status' => 200,
-                'allow_redirect' => true,
-                // 'contains_text' => 'Lorem ipsum dolor sit amet',
+                // 'allow_redirect' => true,
+                'contains_text' => 'Lorem ipsum dolor sit amet',
                 // 'is_json' => false
             ],
             [

--- a/dist/classes/Admin.php
+++ b/dist/classes/Admin.php
@@ -19,7 +19,8 @@ class Admin extends MyAdmin
     use \Nette\SmartObject;
 
     /**
-     * @var array<array> admin search defined for table => [id, field1 to be searched in, field2 to be searched in...]
+     * @var array<array<string>> tables and columns to search in admin
+     * table => [id, field1 to be searched in, field2 to be searched in...]
      */
     protected $searchColumns = [
         'category' => ['id', 'name_#', 'content_#'], // "#" will be replaced by current language

--- a/dist/classes/Admin.php
+++ b/dist/classes/Admin.php
@@ -12,7 +12,7 @@ use function WorkOfStan\MyCMS\ThrowableFunctions\preg_match_all;
 
 /**
  * Admin UI
- * (Last MyCMS/dist revision: 2021-11-04, v0.4.4)
+ * (Last MyCMS/dist revision: 2021-11-05, v0.4.4+)
  */
 class Admin extends MyAdmin
 {

--- a/dist/classes/Admin.php
+++ b/dist/classes/Admin.php
@@ -12,15 +12,14 @@ use function WorkOfStan\MyCMS\ThrowableFunctions\preg_match_all;
 
 /**
  * Admin UI
- * (Last MyCMS/dist revision: 2021-05-28, v0.4.2)
+ * (Last MyCMS/dist revision: 2021-11-04, v0.4.4)
  */
 class Admin extends MyAdmin
 {
     use \Nette\SmartObject;
 
     /**
-     * @var array<array> tables and columns to search in admin
-     * table => [id, field1 to be searched in, field2 to be searched in...]
+     * @var array<array> admin search defined for table => [id, field1 to be searched in, field2 to be searched in...]
      */
     protected $searchColumns = [
         'category' => ['id', 'name_#', 'content_#'], // "#" will be replaced by current language

--- a/dist/classes/AdminProcess.php
+++ b/dist/classes/AdminProcess.php
@@ -18,7 +18,7 @@ define('PROCESS_LIMIT', 100); // used in self::getAgenda
 
 /**
  * AJAX and form handling for Admin UI
- * (Last MyCMS/dist revision: 2021-05-28, v0.4.2)
+ * (Last MyCMS/dist revision: 2021-11-05, v0.4.4+)
  */
 class AdminProcess extends MyAdminProcess
 {

--- a/dist/classes/AdminProcess.php
+++ b/dist/classes/AdminProcess.php
@@ -31,7 +31,7 @@ class AdminProcess extends MyAdminProcess
      * accepted attributes:
      */
 
-    /** @var array<array> */
+    /** @var array<array<string>> */
     protected $agendas;
 
     /**
@@ -458,7 +458,7 @@ class AdminProcess extends MyAdminProcess
      * It is public for PHPUnit test
      *
      * @param string $agenda
-     * @return array<array>
+     * @return array<array<string|array>>
      */
     public function getAgenda($agenda)
     {
@@ -466,7 +466,7 @@ class AdminProcess extends MyAdminProcess
             return [];
         }
         $result = $correctOrder = [];
-        /** @var array<string|array> $options array of agenda set in admin.php in $AGENDAS */
+        /** @var array<string|array<mixed>> $options array of agenda set in admin.php in $AGENDAS */
         $options = $this->agendas[$agenda];
         $optionsTable = (isset($options['table']) && is_string($options['table'])) ?
             ($options['table'] ?: $agenda) : $agenda;

--- a/dist/classes/AdminProcess.php
+++ b/dist/classes/AdminProcess.php
@@ -31,7 +31,7 @@ class AdminProcess extends MyAdminProcess
      * accepted attributes:
      */
 
-    /** @var array<array<string>> */
+    /** @var array<array<string|array<string|int>>> */
     protected $agendas;
 
     /**
@@ -39,7 +39,7 @@ class AdminProcess extends MyAdminProcess
      * Commands with all required variables cause page redirection.
      * $_SESSION is manipulated by this function - mainly [messages] get added
      *
-     * @param array<string|array> $post $_POST by reference
+     * @param array<string|array<mixed>> $post $_POST by reference
      * @todo refactor, so that $this->endAdmin(); is called automatically
      *
      * @return void
@@ -458,7 +458,7 @@ class AdminProcess extends MyAdminProcess
      * It is public for PHPUnit test
      *
      * @param string $agenda
-     * @return array<array<string|array>>
+     * @return array<array<string|array<mixed>>>
      */
     public function getAgenda($agenda)
     {

--- a/dist/classes/AdminProcess.php
+++ b/dist/classes/AdminProcess.php
@@ -31,7 +31,7 @@ class AdminProcess extends MyAdminProcess
      * accepted attributes:
      */
 
-    /** @var array<array<string|array<string|int>>> */
+    /** @var array<array<mixed>> */
     protected $agendas;
 
     /**

--- a/dist/classes/Controller.php
+++ b/dist/classes/Controller.php
@@ -286,7 +286,7 @@ class Controller extends MyController
     /**
      * For PHP Unit test
      *
-     * @return array<array>
+     * @return array<array<mixed>>
      */
     public function getVars()
     {

--- a/dist/classes/MyCMSProject.php
+++ b/dist/classes/MyCMSProject.php
@@ -26,7 +26,7 @@ class MyCMSProject extends MyCMS
     /** @var array<mixed> */
     public $SETTINGS;
 
-    /** @var array<array> */
+    /** @var array<array<string|array<array<string>>>> */
     public $WEBSITE;
 
     /**

--- a/dist/classes/ProjectSpecific.php
+++ b/dist/classes/ProjectSpecific.php
@@ -31,7 +31,7 @@ class ProjectSpecific extends ProjectCommon
      * @param string $totalRows //TODO or?? mixed $totalRows first selected row
      *     (or its first column if only one column is selected),
      *     null on empty SELECT, or false on error
-     * @return array<array> search result
+     * @return array<array<string>> search result
      */
     public function searchResults($text, $offset = 0, $limit = 10, &$totalRows = null)
     {
@@ -233,7 +233,7 @@ class ProjectSpecific extends ProjectCommon
      * TODO: make this method useful for dist project as a demonstration (inspired by A project)
      *
      * @param string $path
-     * @return array<array|string>|false
+     * @return array<array<string>|string>|false
      */
     public function getBreadcrumbs($path)
     {
@@ -258,7 +258,8 @@ class ProjectSpecific extends ProjectCommon
      *          [path] - path of the category
      *          [level] - level to which seek for children
      *          [except_id] - id of the child to omit from the result
-     * @return array<array|string|int>|false - either associative array, empty array on empty SELECT, or false on error
+     * @return array<array<string|int>|string|int>|false
+     *          either associative array, empty array on empty SELECT, or false on error
      */
     public function getChildren($category_id, array $options = [])
     {

--- a/dist/composer.json
+++ b/dist/composer.json
@@ -3,7 +3,7 @@
     "description": "MYCMSPROJECTSPECIFIC xyz website 202x",
     "type": "project",
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^5.6|^7.0",
         "workofstan/mycms": "dev-main",
         "robmorgan/phinx": "^0.10.6|^0.12.3",
         "swiftmailer/swiftmailer": "^5.4|^6.2",

--- a/dist/conf/config.php
+++ b/dist/conf/config.php
@@ -29,7 +29,7 @@ $backyardConf = [
     'logging_level' => 3,
     'error_log_message_type' => 3,
     'logging_file' => __DIR__ . '/../log/backyard-error.log',
-    //'mail_for_admin_enabled' => true,
+    'mail_for_admin_enabled' => false,
 ];
 
 $debugIpArray = [

--- a/dist/conf/config.php
+++ b/dist/conf/config.php
@@ -201,7 +201,7 @@ foreach ($arrayOfConstants as $constant => $value) {
 }
 // If you want to receive fatal errors in mail, set in config.local.php: $backyardConf['mail_for_admin_enabled'] = true;
 $backyardConf['mail_for_admin_enabled'] = (
-    isset($backyardConf['mail_for_admin_enabled']) && $backyardConf['mail_for_admin_enabled']
+    array_key_exists('mail_for_admin_enabled', $backyardConf) && $backyardConf['mail_for_admin_enabled']
 ) ? EMAIL_ADMIN : false;
 
 // default values for feature flags (use keys without spaces to avoid problems in javascript)

--- a/dist/conf/config.php
+++ b/dist/conf/config.php
@@ -29,7 +29,7 @@ $backyardConf = [
     'logging_level' => 3,
     'error_log_message_type' => 3,
     'logging_file' => __DIR__ . '/../log/backyard-error.log',
-    'mail_for_admin_enabled' => false,
+    //'mail_for_admin_enabled' => true,
 ];
 
 $debugIpArray = [
@@ -200,9 +200,10 @@ foreach ($arrayOfConstants as $constant => $value) {
     }
 }
 // If you want to receive fatal errors in mail, set in config.local.php: $backyardConf['mail_for_admin_enabled'] = true;
-if (isset($backyardConf['mail_for_admin_enabled']) && $backyardConf['mail_for_admin_enabled']) {
-    $backyardConf['mail_for_admin_enabled'] = EMAIL_ADMIN;
-}
+$backyardConf['mail_for_admin_enabled'] = (
+    isset($backyardConf['mail_for_admin_enabled']) && $backyardConf['mail_for_admin_enabled']
+) ? EMAIL_ADMIN : false;
+
 // default values for feature flags (use keys without spaces to avoid problems in javascript)
 $featureFlags = array_merge(
     [

--- a/dist/conf/phpstan.app.neon
+++ b/dist/conf/phpstan.app.neon
@@ -115,8 +115,14 @@ parameters:
         message: '#Undefined variable: \$translation#'
         path: ../classes/Admin.php
       # The exceptions concerning always false/true compensate for environment dependent variables.
+      #-
+      #  message: '#Right side of && is always false.#'
+      #  path: config.php
+      #-
+      #  message: '#Call to function array_key_exists() with 'mail_for_admin…' and array{logging_level: 3, error_log_message_type: 3, logging_file: '/home/runner/work…'} will always evaluate to false.#'
+      #  path: config.php
       -
-        message: '#Right side of && is always false.#'
+        message: '#Result of && is always false.#'
         path: config.php
       # Compensate for PHPUnit where $_POST may not be defined
       -

--- a/dist/conf/phpstan.app.neon
+++ b/dist/conf/phpstan.app.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 7
+    level: 8
     excludePaths:
         analyseAndScan:
             - ../cache/*
@@ -115,15 +115,15 @@ parameters:
         message: '#Undefined variable: \$translation#'
         path: ../classes/Admin.php
       # The exceptions concerning always false/true compensate for environment dependent variables.
+      -
+        message: '#Right side of && is always false.#'
+        path: config.php
       #-
-      #  message: '#Right side of && is always false.#'
+      #  message: "#Call to function array_key_exists\\(\\) with 'mail_for_admin…' and array{logging_level: 3, error_log_message_type: 3, logging_file: '/home/runner/work…'} will always evaluate to false.#"
       #  path: config.php
-      -
-        message: "#Call to function array_key_exists\\(\\) with 'mail_for_admin…' and array{logging_level: 3, error_log_message_type: 3, logging_file: '/home/runner/work…'} will always evaluate to false.#"
-        path: config.php
-      -
-        message: '#Result of && is always false.#'
-        path: config.php
+      #-
+      #  message: '#Result of && is always false.#'
+      #  path: config.php
       # Compensate for PHPUnit where $_POST may not be defined
       -
         message: '#Result of \|\| is always false.#'

--- a/dist/conf/phpstan.app.neon
+++ b/dist/conf/phpstan.app.neon
@@ -1,3 +1,7 @@
+includes:
+      # Ignore errors in rector.php when rector/rector is not installed
+      - phpstan.rector.neon
+
 parameters:
     level: 8
     excludePaths:

--- a/dist/conf/phpstan.app.neon
+++ b/dist/conf/phpstan.app.neon
@@ -1,7 +1,3 @@
-includes:
-      # Ignore errors in rector.php when rector/rector is not installed
-      - phpstan.rector.neon
-
 parameters:
     level: 8
     excludePaths:

--- a/dist/conf/phpstan.app.neon
+++ b/dist/conf/phpstan.app.neon
@@ -118,12 +118,6 @@ parameters:
       -
         message: '#Right side of && is always false.#'
         path: config.php
-      #-
-      #  message: "#Call to function array_key_exists\\(\\) with 'mail_for_admin…' and array{logging_level: 3, error_log_message_type: 3, logging_file: '/home/runner/work…'} will always evaluate to false.#"
-      #  path: config.php
-      #-
-      #  message: '#Result of && is always false.#'
-      #  path: config.php
       # Compensate for PHPUnit where $_POST may not be defined
       -
         message: '#Result of \|\| is always false.#'

--- a/dist/conf/phpstan.app.neon
+++ b/dist/conf/phpstan.app.neon
@@ -119,7 +119,7 @@ parameters:
       #  message: '#Right side of && is always false.#'
       #  path: config.php
       -
-        message: "#Call to function array_key_exists\(\) with 'mail_for_admin…' and array{logging_level: 3, error_log_message_type: 3, logging_file: '/home/runner/work…'} will always evaluate to false.#"
+        message: "#Call to function array_key_exists\\(\\) with 'mail_for_admin…' and array{logging_level: 3, error_log_message_type: 3, logging_file: '/home/runner/work…'} will always evaluate to false.#"
         path: config.php
       -
         message: '#Result of && is always false.#'

--- a/dist/conf/phpstan.app.neon
+++ b/dist/conf/phpstan.app.neon
@@ -118,9 +118,9 @@ parameters:
       #-
       #  message: '#Right side of && is always false.#'
       #  path: config.php
-      #-
-      #  message: '#Call to function array_key_exists() with 'mail_for_admin…' and array{logging_level: 3, error_log_message_type: 3, logging_file: '/home/runner/work…'} will always evaluate to false.#'
-      #  path: config.php
+      -
+        message: "#Call to function array_key_exists() with 'mail_for_admin…' and array{logging_level: 3, error_log_message_type: 3, logging_file: '/home/runner/work…'} will always evaluate to false.#"
+        path: config.php
       -
         message: '#Result of && is always false.#'
         path: config.php

--- a/dist/conf/phpstan.app.neon
+++ b/dist/conf/phpstan.app.neon
@@ -119,7 +119,7 @@ parameters:
       #  message: '#Right side of && is always false.#'
       #  path: config.php
       -
-        message: "#Call to function array_key_exists() with 'mail_for_admin…' and array{logging_level: 3, error_log_message_type: 3, logging_file: '/home/runner/work…'} will always evaluate to false.#"
+        message: "#Call to function array_key_exists\(\) with 'mail_for_admin…' and array{logging_level: 3, error_log_message_type: 3, logging_file: '/home/runner/work…'} will always evaluate to false.#"
         path: config.php
       -
         message: '#Result of && is always false.#'

--- a/dist/conf/phpstan.app.neon
+++ b/dist/conf/phpstan.app.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: max
+    level: 7
     excludePaths:
         analyseAndScan:
             - ../cache/*

--- a/dist/conf/phpstan.rector.neon
+++ b/dist/conf/phpstan.rector.neon
@@ -3,13 +3,13 @@ parameters:
     ignoreErrors:
       -
         message: "#^Access to constant OLD_TO_NEW_NAMESPACES on an unknown class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector\\.$#"
-    count: 1
-    path: ../rector.php
+        count: 1
+        path: ../rector.php
       -
-    message: "#^Access to constant PATHS on an unknown class Rector\\\\Core\\\\Configuration\\\\Option\\.$#"
-    count: 1
-    path: ../rector.php
+        message: "#^Access to constant PATHS on an unknown class Rector\\\\Core\\\\Configuration\\\\Option\\.$#"
+        count: 1
+        path: ../rector.php
       -
-    message: "#^Class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector not found\\.$#"
-    count: 1
-    path: ../rector.php
+        message: "#^Class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector not found\\.$#"
+        count: 1
+        path: ../rector.php

--- a/dist/conf/phpstan.rector.neon
+++ b/dist/conf/phpstan.rector.neon
@@ -1,17 +1,16 @@
 # PHPSTAN level = 8
 parameters:
-	ignoreErrors:
-		-
-			message: "#^Access to constant OLD_TO_NEW_NAMESPACES on an unknown class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector\\.$#"
-			count: 1
-			path: ../rector.php
+    ignoreErrors:
+      -
+        message: "#^Access to constant OLD_TO_NEW_NAMESPACES on an unknown class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector\\.$#"
+	count: 1
+	path: ../rector.php
+      -
+	message: "#^Access to constant PATHS on an unknown class Rector\\\\Core\\\\Configuration\\\\Option\\.$#"
+	count: 1
+	path: ../rector.php
 
-		-
-			message: "#^Access to constant PATHS on an unknown class Rector\\\\Core\\\\Configuration\\\\Option\\.$#"
-			count: 1
-			path: ../rector.php
-
-		-
-			message: "#^Class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector not found\\.$#"
-			count: 1
-			path: ../rector.php
+      -
+	message: "#^Class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector not found\\.$#"
+	count: 1
+	path: ../rector.php

--- a/dist/conf/phpstan.rector.neon
+++ b/dist/conf/phpstan.rector.neon
@@ -6,10 +6,10 @@ parameters:
 			count: 1
 			path: ../rector.php
 
-		#-
-		#	message: "#^Access to constant PATHS on an unknown class Rector\\\\Core\\\\Configuration\\\\Option\\.$#"
-		#	count: 1
-		#	path: ../rector.php
+		-
+			message: "#^Access to constant PATHS on an unknown class Rector\\\\Core\\\\Configuration\\\\Option\\.$#"
+			count: 1
+			path: ../rector.php
 
 		-
 			message: "#^Class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector not found\\.$#"

--- a/dist/conf/phpstan.rector.neon
+++ b/dist/conf/phpstan.rector.neon
@@ -6,10 +6,10 @@ parameters:
 			count: 1
 			path: ../rector.php
 
-		-
-			message: "#^Access to constant PATHS on an unknown class Rector\\\\Core\\\\Configuration\\\\Option\\.$#"
-			count: 1
-			path: ../rector.php
+		#-
+		#	message: "#^Access to constant PATHS on an unknown class Rector\\\\Core\\\\Configuration\\\\Option\\.$#"
+		#	count: 1
+		#	path: ../rector.php
 
 		-
 			message: "#^Class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector not found\\.$#"

--- a/dist/conf/phpstan.rector.neon
+++ b/dist/conf/phpstan.rector.neon
@@ -1,0 +1,17 @@
+# PHPSTAN level = 8
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Access to constant OLD_TO_NEW_NAMESPACES on an unknown class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector\\.$#"
+			count: 1
+			path: ../rector.php
+
+		-
+			message: "#^Access to constant PATHS on an unknown class Rector\\\\Core\\\\Configuration\\\\Option\\.$#"
+			count: 1
+			path: ../rector.php
+
+		-
+			message: "#^Class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector not found\\.$#"
+			count: 1
+			path: ../rector.php

--- a/dist/conf/phpstan.rector.neon
+++ b/dist/conf/phpstan.rector.neon
@@ -3,14 +3,13 @@ parameters:
     ignoreErrors:
       -
         message: "#^Access to constant OLD_TO_NEW_NAMESPACES on an unknown class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector\\.$#"
-	count: 1
-	path: ../rector.php
+    count: 1
+    path: ../rector.php
       -
-	message: "#^Access to constant PATHS on an unknown class Rector\\\\Core\\\\Configuration\\\\Option\\.$#"
-	count: 1
-	path: ../rector.php
-
+    message: "#^Access to constant PATHS on an unknown class Rector\\\\Core\\\\Configuration\\\\Option\\.$#"
+    count: 1
+    path: ../rector.php
       -
-	message: "#^Class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector not found\\.$#"
-	count: 1
-	path: ../rector.php
+    message: "#^Class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector not found\\.$#"
+    count: 1
+    path: ../rector.php

--- a/dist/conf/phpstan.webmozart-assert.neon
+++ b/dist/conf/phpstan.webmozart-assert.neon
@@ -4,3 +4,5 @@ includes:
       # to use https://github.com/phpstan/phpstan-webmozart-assert
       # phpstan/phpstan-webmozart-assert requires this settings
       - ../vendor/phpstan/phpstan-webmozart-assert/extension.neon
+      # Ignore errors in rector.php when rector/rector is not installed
+      - phpstan.rector.neon

--- a/dist/conf/phpstan.webmozart-assert.neon
+++ b/dist/conf/phpstan.webmozart-assert.neon
@@ -4,5 +4,3 @@ includes:
       # to use https://github.com/phpstan/phpstan-webmozart-assert
       # phpstan/phpstan-webmozart-assert requires this settings
       - ../vendor/phpstan/phpstan-webmozart-assert/extension.neon
-      # Ignore errors in rector.php when rector/rector is not installed
-      - phpstan.rector.neon

--- a/dist/phpstan-remove.sh
+++ b/dist/phpstan-remove.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+composer remove --dev phpstan/phpstan-webmozart-assert

--- a/dist/phpstan.sh
+++ b/dist/phpstan.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+#composer require --dev phpstan/phpstan-webmozart-assert:^0.12 --prefer-dist --no-progress
+composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
+
+vendor/bin/phpunit
+#vendor/bin/phpstan
+vendor/bin/phpstan.phar --configuration=conf/phpstan.webmozart-assert.neon analyse . --memory-limit 300M --pro

--- a/dist/phpstan.sh
+++ b/dist/phpstan.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-#composer require --dev phpstan/phpstan-webmozart-assert:^0.12 --prefer-dist --no-progress
 composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
 
 vendor/bin/phpunit
-#vendor/bin/phpstan
 vendor/bin/phpstan.phar --configuration=conf/phpstan.webmozart-assert.neon analyse . --memory-limit 300M --pro

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -195,18 +195,3 @@ parameters:
 			message: "#^Right side of \\|\\| is always false\\.$#"
 			count: 1
 			path: classes/MyTableLister.php
-
-		-
-			message: "#^Access to constant OLD_TO_NEW_NAMESPACES on an unknown class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector\\.$#"
-			count: 1
-			path: dist/rector.php
-
-		-
-			message: "#^Access to constant PATHS on an unknown class Rector\\\\Core\\\\Configuration\\\\Option\\.$#"
-			count: 1
-			path: dist/rector.php
-
-		-
-			message: "#^Class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector not found\\.$#"
-			count: 1
-			path: dist/rector.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -196,17 +196,17 @@ parameters:
 			count: 1
 			path: classes/MyTableLister.php
 
-		#-
-		#	message: "#^Access to constant OLD_TO_NEW_NAMESPACES on an unknown class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector\\.$#"
-		#	count: 1
-		#	path: dist/rector.php
+		-
+			message: "#^Access to constant OLD_TO_NEW_NAMESPACES on an unknown class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector\\.$#"
+			count: 1
+			path: dist/rector.php
 
-		#-
-		#	message: "#^Access to constant PATHS on an unknown class Rector\\\\Core\\\\Configuration\\\\Option\\.$#"
-		#	count: 1
-		#	path: dist/rector.php
+		-
+			message: "#^Access to constant PATHS on an unknown class Rector\\\\Core\\\\Configuration\\\\Option\\.$#"
+			count: 1
+			path: dist/rector.php
 
-		#-
-		#	message: "#^Class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector not found\\.$#"
-		#	count: 1
-		#	path: dist/rector.php
+		-
+			message: "#^Class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector not found\\.$#"
+			count: 1
+			path: dist/rector.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -196,17 +196,17 @@ parameters:
 			count: 1
 			path: classes/MyTableLister.php
 
-		-
-			message: "#^Access to constant OLD_TO_NEW_NAMESPACES on an unknown class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector\\.$#"
-			count: 1
-			path: dist/rector.php
+		#-
+		#	message: "#^Access to constant OLD_TO_NEW_NAMESPACES on an unknown class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector\\.$#"
+		#	count: 1
+		#	path: dist/rector.php
 
-		-
-			message: "#^Access to constant PATHS on an unknown class Rector\\\\Core\\\\Configuration\\\\Option\\.$#"
-			count: 1
-			path: dist/rector.php
+		#-
+		#	message: "#^Access to constant PATHS on an unknown class Rector\\\\Core\\\\Configuration\\\\Option\\.$#"
+		#	count: 1
+		#	path: dist/rector.php
 
-		-
-			message: "#^Class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector not found\\.$#"
-			count: 1
-			path: dist/rector.php
+		#-
+		#	message: "#^Class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector not found\\.$#"
+		#	count: 1
+		#	path: dist/rector.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,212 @@
+# PHPSTAN level = 8
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\LogMysqli\\:\\:listColumns\\(\\) has parameter \\$fields with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/LogMysqli.php
+
+		-
+			message: "#^Property WorkOfStan\\\\MyCMS\\\\MyAdmin\\:\\:\\$TableAdmin \\(WorkOfStan\\\\MyCMS\\\\MyTableAdmin\\) in empty\\(\\) is not falsy\\.$#"
+			count: 1
+			path: classes/MyAdmin.php
+
+		-
+			message: "#^Property WorkOfStan\\\\MyCMS\\\\MyAdmin\\:\\:\\$searchColumns type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyAdmin.php
+
+		-
+			message: "#^Property WorkOfStan\\\\MyCMS\\\\MyAdmin\\:\\:\\$tableAdmin \\(WorkOfStan\\\\MyCMS\\\\MyTableAdmin\\) in empty\\(\\) is not falsy\\.$#"
+			count: 1
+			path: classes/MyAdmin.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyAdminProcess\\:\\:processActivity\\(\\) has parameter \\$post with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyAdminProcess.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyAdminProcess\\:\\:processClone\\(\\) has parameter \\$post with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyAdminProcess.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyAdminProcess\\:\\:processExport\\(\\) has parameter \\$get with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyAdminProcess.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyAdminProcess\\:\\:processExport\\(\\) has parameter \\$post with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyAdminProcess.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyAdminProcess\\:\\:processFileDelete\\(\\) has parameter \\$post with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyAdminProcess.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyAdminProcess\\:\\:processFilePack\\(\\) has parameter \\$post with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyAdminProcess.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyAdminProcess\\:\\:processFileRename\\(\\) has parameter \\$post with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyAdminProcess.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyAdminProcess\\:\\:processFileUnpack\\(\\) has parameter \\$post with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyAdminProcess.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyAdminProcess\\:\\:processFileUpload\\(\\) has parameter \\$post with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyAdminProcess.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyAdminProcess\\:\\:processLogin\\(\\) has parameter \\$post with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyAdminProcess.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyAdminProcess\\:\\:processLogout\\(\\) has parameter \\$post with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyAdminProcess.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyAdminProcess\\:\\:processSubfolder\\(\\) has parameter \\$post with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyAdminProcess.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyAdminProcess\\:\\:processUserActivation\\(\\) has parameter \\$post with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyAdminProcess.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyAdminProcess\\:\\:processUserChangePassword\\(\\) has parameter \\$post with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyAdminProcess.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyAdminProcess\\:\\:processUserCreate\\(\\) has parameter \\$post with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyAdminProcess.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyAdminProcess\\:\\:processUserDelete\\(\\) has parameter \\$post with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyAdminProcess.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyCMSMonoLingual\\:\\:__construct\\(\\) has parameter \\$myCmsConf with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyCMSMonoLingual.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyCMSMonoLingual\\:\\:fetchAndReindexStrictArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyCMSMonoLingual.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyController\\:\\:controller\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyController.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyController\\:\\:getVars\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyController.php
+
+		-
+			message: "#^Property WorkOfStan\\\\MyCMS\\\\MyController\\:\\:\\$friendlyUrl \\(WorkOfStan\\\\MyCMS\\\\MyFriendlyUrl\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: classes/MyController.php
+
+		-
+			message: "#^Property WorkOfStan\\\\MyCMS\\\\MyController\\:\\:\\$get type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyController.php
+
+		-
+			message: "#^Property WorkOfStan\\\\MyCMS\\\\MyController\\:\\:\\$result type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyController.php
+
+		-
+			message: "#^Property WorkOfStan\\\\MyCMS\\\\MyController\\:\\:\\$session type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyController.php
+
+		-
+			message: "#^Left side of && is always true\\.$#"
+			count: 1
+			path: classes/MyTableAdmin.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyTableAdmin\\:\\:addForeignOption\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyTableAdmin.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyTableAdmin\\:\\:outputForeignId\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyTableAdmin.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyTableAdmin\\:\\:outputForeignId\\(\\) has parameter \\$values with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyTableAdmin.php
+
+		-
+			message: "#^Variable \\$query in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: classes/MyTableAdmin.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyTableLister\\:\\:bulkUpdateSQL\\(\\) has parameter \\$vars with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyTableLister.php
+
+		-
+			message: "#^Method WorkOfStan\\\\MyCMS\\\\MyTableLister\\:\\:getColumns\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyTableLister.php
+
+		-
+			message: "#^Property WorkOfStan\\\\MyCMS\\\\MyTableLister\\:\\:\\$fields type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyTableLister.php
+
+		-
+			message: "#^Property WorkOfStan\\\\MyCMS\\\\MyTableLister\\:\\:\\$tableContext type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyTableLister.php
+
+		-
+			message: "#^Property WorkOfStan\\\\MyCMS\\\\MyTableLister\\:\\:\\$tables type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: classes/MyTableLister.php
+
+		-
+			message: "#^Right side of \\|\\| is always false\\.$#"
+			count: 1
+			path: classes/MyTableLister.php
+
+		-
+			message: "#^Access to constant OLD_TO_NEW_NAMESPACES on an unknown class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector\\.$#"
+			count: 1
+			path: dist/rector.php
+
+		-
+			message: "#^Access to constant PATHS on an unknown class Rector\\\\Core\\\\Configuration\\\\Option\\.$#"
+			count: 1
+			path: dist/rector.php
+
+		-
+			message: "#^Class Rector\\\\Renaming\\\\Rector\\\\Namespace_\\\\RenameNamespaceRector not found\\.$#"
+			count: 1
+			path: dist/rector.php

--- a/phpstan-remove.sh
+++ b/phpstan-remove.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+composer remove --dev phpstan/phpstan-webmozart-assert

--- a/phpstan-remove.sh
+++ b/phpstan-remove.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 composer remove --dev phpstan/phpstan-webmozart-assert
+composer remove --dev rector/rector

--- a/phpstan.sh
+++ b/phpstan.sh
@@ -4,5 +4,4 @@
 composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
 
 vendor/bin/phpunit
-#vendor/bin/phpstan
 vendor/bin/phpstan.phar --configuration=conf/phpstan.webmozart-assert.neon analyse . --memory-limit 300M --pro

--- a/phpstan.sh
+++ b/phpstan.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+#composer require --dev phpstan/phpstan-phpunit --prefer-dist --no-progress
 # Note: rector/rector:0.11.60 => phpstan/phpstan:0.12.99 (i.e. prevents phpstan/phpstan:1.0.2)
 #composer require --dev rector/rector --prefer-dist --no-progress
 #composer require --dev phpstan/phpstan-webmozart-assert:^0.12 --prefer-dist --no-progress

--- a/phpstan.sh
+++ b/phpstan.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+#composer require --dev phpstan/phpstan-webmozart-assert:^0.12 --prefer-dist --no-progress
+composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
+
+vendor/bin/phpunit
+#vendor/bin/phpstan
+vendor/bin/phpstan.phar --configuration=conf/phpstan.webmozart-assert.neon analyse . --memory-limit 300M --pro

--- a/phpstan.sh
+++ b/phpstan.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Note: rector/rector:0.11.60 => phpstan/phpstan:0.12.99 (i.e. prevents phpstan/phpstan:1.0.2)
+#composer require --dev rector/rector --prefer-dist --no-progress
 #composer require --dev phpstan/phpstan-webmozart-assert:^0.12 --prefer-dist --no-progress
 composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
 


### PR DESCRIPTION
- added phpstan.sh and phpstan-remove.sh for local testing
- added phpstan-baseline.neon to hide type hint imperfections in PHPStan level=8 (TODO fix these)
- PHPStan level lowered to 8 due to stricter PHPStan:1.0
- fixed some type hint imperfections (especially for nested arrays) in PHPStan level=8
