### PR TITLE
$myCmsConf is mixed[]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - dist/set-environment.php moved to dist/conf/set-environment.php
 - $this->verboseBarDump returns mixed, so taken out of return statements (for smooth static analysis)
 - MyTableLister::bulkUpdateSQL passes $vars by value (it's not necessary to pass by reference)
+- $myCmsConf is mixed[] (instead of complex and not future usage proof array<array<array<array<string>,bool,string>,string>|BackyardError|LogMysqli|null> )
 
 ### `Deprecated` for soon-to-be removed features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MyTools::h(mixed) - Tools::h that accepts mixed but throws exception if it isn't a string
 - MyController::run getter for template and context to narrow the type hints
 - MyCMSMonoLingual::fetchAndReindexStrictArray refactored to return the expected array structure
+- MyCMSMonoLingual::fetchAndReindexStrictArray displays the SQL bar panel in case of Assertion thrown Exception
 
 ### `Changed` for changes in existing functionality
 - **BREAKING CHANGE** MyFriendlyUrl::determineTemplate change from `@return string|array<string>|true` to `@return string|array<int|string>|true`
@@ -34,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - dist/set-environment.php moved to dist/conf/set-environment.php
 - $this->verboseBarDump returns mixed, so taken out of return statements (for smooth static analysis)
 - MyTableLister::bulkUpdateSQL passes $vars by value (it's not necessary to pass by reference)
-- $myCmsConf is mixed[] (instead of complex and not future usage proof array<array<array<array<string>,bool,string>,string>|BackyardError|LogMysqli|null> )
+- $myCmsConf is mixed[] (instead of complex and not future usage proof array<array<array<array<string>,bool,string>,string>|BackyardError|LogMysqli|null> ) For some fields, there is a runtime assertion.
 
 ### `Deprecated` for soon-to-be removed features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - $this->verboseBarDump returns mixed, so taken out of return statements (for smooth static analysis)
 - MyTableLister::bulkUpdateSQL passes $vars by value (it's not necessary to pass by reference)
 - $myCmsConf is mixed[] (instead of complex and not future usage proof array<array<array<array<string>,bool,string>,string>|BackyardError|LogMysqli|null> ) For some fields, there is a runtime assertion.
+- workofstan/backyard bumped to ^3.3.1
 
 ### `Deprecated` for soon-to-be removed features
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ because MySQLi environment isn't prepared (yet) and HTTP requests to self can't 
 
 ### PHPStan
 
-Till only PHP<7.1 is supported, neither `phpstan/phpstan-webmozart-assert` nor `rector/rector` can't be required-dev in composer.json.
+Till PHP<7.1 is supported, neither `phpstan/phpstan-webmozart-assert` nor `rector/rector` can't be required-dev in composer.json.
 Therefore, to properly take into account Assert statements by PHPStan (relevant for level>6), do a temporary (i.e. without commiting it to repository)
 ```sh
 composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![PHP Composer + PHPUnit + PHPStan](https://github.com/WorkOfStan/mycms/actions/workflows/php-composer-phpunit.yml/badge.svg)](https://github.com/WorkOfStan/mycms/actions/workflows/php-composer-phpunit.yml)
 
 Brief MVC framework for interactive sites including general administration.
-Works as a devstack which you install and then write your classes specific for the project.
-The boilerplate project is prepared in `dist` folder to be adapted as needed and it uses this `WorkOfStan\MyCMS` library out-of-the-box.
+Works as a devstack which you install and then write your classes specific for your application.
+The boilerplate application is prepared in `dist` folder to be adapted as needed and it uses this `WorkOfStan\MyCMS` library out-of-the-box.
 
 MyCMS is designed to be used with following technologies:
 - [jQuery](https://jquery.org/) and [Bootstrap (version 4)](https://getbootstrap.com/docs/4.0/components/): for presentation
@@ -25,7 +25,7 @@ Once [composer](https://getcomposer.org/) is installed, execute the following co
 composer require workofstan/mycms:^0.4.4
 ```
 Most of library's classes use prefix `My`.
-To customize the project, create your own classes as children inheriting MyCMS' classes in the `./classes/` directory and name them without the initial `My` in its name.  
+To customize your application, create your own classes as children inheriting MyCMS' classes in the `./classes/` directory and name them without the initial `My` in its name.  
 
 ```php
 $MyCMS = new \WorkOfStan\MyCMS\MyCMS(
@@ -40,17 +40,17 @@ $MyCMS = new \WorkOfStan\MyCMS\MyCMS(
 $MyCMS->renderLatte(DIR_TEMPLATE_CACHE, "\\vendor\\ProjectName\\Latte\\CustomFilters::common", $params);
 ```
 
-Files `process.php` and `admin-process.php` MUST exist and process forms.
+Files `process.php` and `admin-process.php` MUST exist as they process forms.
 
 Note: `$MyCMS` name is expected by `ProjectSpecific extends ProjectCommon` class (@todo replace global $MyCMS by parameter handling)
 
 ## Deployment
 
 ### `/dist`
-Folder `/dist` contains initial *distribution* files for a new project using MyCMS, therefore copy it to your new project folder in order to easily start.
-Replace the string `MYCMSPROJECTNAMESPACE` with your project namespace.
+Folder `/dist` contains initial *distribution* files for a new project using MyCMS, therefore copy it to your new project folder in order to start easily.
+Replace the string `MYCMSPROJECTNAMESPACE` with your project namespace. (TODO: rector...)
 Replace the string `MYCMSPROJECTSPECIFIC` with other site specific information (Brand, Twitter address, phone number, database table_prefix in phinx.yml...).
-If you want to use your own table name prefix, it is recommanded to change database related strings before first running [`./build.sh`](dist/build.sh).
+If you want to use your own table name prefix, please change the database related strings before first running [`./build.sh`](dist/build.sh).
 
 To adapt the content and its structure either adapt migrations [content_table](dist/db/migrations/20200607204634_content_table.php) and [content_example](dist/db/migrations/20200703213436_content_example.php)
 before first running build
@@ -172,13 +172,20 @@ because MySQLi environment isn't prepared (yet) and HTTP requests to self can't 
 
 ### PHPStan
 
-Till PHP<7.1 is supported, neither `phpstan/phpstan-webmozart-assert` nor `rector/rector` can't be required-dev in composer.json.
+Till only PHP<7.1 is supported, neither `phpstan/phpstan-webmozart-assert` nor `rector/rector` can't be required-dev in composer.json.
 Therefore, to properly take into account Assert statements by PHPStan (relevant for level>6), do a temporary (i.e. without commiting it to repository)
 ```sh
 composer require --dev phpstan/phpstan-webmozart-assert --prefer-dist --no-progress
 composer require --dev rector/rector --prefer-dist --no-progress
 ```
 and use [conf/phpstan.webmozart-assert.neon](conf/phpstan.webmozart-assert.neon) to allow for `phpstan --configuration=conf/phpstan.webmozart-assert.neon analyse . --memory-limit 300M`.
+
+Prepared scripts
+[./phpstan.sh](phpstan.sh)
+and
+[./phpstan-remove.sh](phpstan-remove.sh)
+can be used to start (or remove) the static analysis.
+(TODO: call the dist scripts from root to DRY.)
 
 ## How does Friendly URL works within Controller
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![PHP Composer + PHPUnit + PHPStan](https://github.com/WorkOfStan/mycms/actions/workflows/php-composer-phpunit.yml/badge.svg)](https://github.com/WorkOfStan/mycms/actions/workflows/php-composer-phpunit.yml)
 
 Brief MVC framework for interactive sites including general administration.
-Works as a devstack which you install and then write your classes specific for your application.
-The boilerplate application is prepared in `dist` folder to be adapted as needed and it uses this `WorkOfStan\MyCMS` library out-of-the-box.
+Works as a devstack which you install and then write your classes specific for your project.
+The boilerplate project is prepared in `dist` folder to be adapted as needed and it uses this `WorkOfStan\MyCMS` library out-of-the-box.
 
 MyCMS is designed to be used with following technologies:
 - [jQuery](https://jquery.org/) and [Bootstrap (version 4)](https://getbootstrap.com/docs/4.0/components/): for presentation
@@ -22,10 +22,10 @@ Apache modules `mod_alias` (for hiding non-public files) and `mod_rewrite` (for 
 
 Once [composer](https://getcomposer.org/) is installed, execute the following command in your project root to install this library:
 ```sh
-composer require workofstan/mycms:^0.4.4
+composer require workofstan/mycms:^0.4.5
 ```
 Most of library's classes use prefix `My`.
-To customize your application, create your own classes as children inheriting MyCMS' classes in the `./classes/` directory and name them without the initial `My` in its name.  
+To develop your project, create your own classes as children inheriting MyCMS' classes in the `./classes/` directory and name them without the initial `My` in its name.  
 
 ```php
 $MyCMS = new \WorkOfStan\MyCMS\MyCMS(
@@ -62,7 +62,7 @@ The table with users and hashed passwords is named `TAB_PREFIX . 'admin'`.
 It is recommanded to adapt classes Contoller.php, FriendlyUrl.php and ProjectSpecific.php to your needs following the recommendations in comments.
 For deployment look also to [Deployment chapter](dist/README.md#deployment) and [Language management](dist/README.md#language-management) in dist/README.md.
 
-MyCMS is used only as a library, so the application using it SHOULD implement `RedirectMatch 404 vendor\/` statement as prepared in `dist/.htaccess` to keep the library hidden from web access.
+MyCMS is used only as a library, so the project using it SHOULD implement `RedirectMatch 404 vendor\/` statement as prepared in `dist/.htaccess` to keep the library hidden from web access.
 
 ## Admin UI
 Admin UI is displayed by MyAdmin::outputAdmin in this structure:

--- a/classes/LogMysqli.php
+++ b/classes/LogMysqli.php
@@ -103,6 +103,7 @@ class LogMysqli extends BackyardMysqli
     {
         $result = $this->queryArray($sql, false); // returns two dimensional array
         if ($result === false) {
+            // TODO add `$this->showSqlBarPanel();` ? in order to display SQL statements?
             throw new Exception('Empty result or database error');
         }
         return $result;
@@ -125,11 +126,13 @@ class LogMysqli extends BackyardMysqli
         $result = $this->query($sql, $errorLogOutput, $logQuery);
 
         if ($result === false) {
+            // TODO add `$this->showSqlBarPanel();` ? in order to display SQL statements?
             throw new Exception($this->errno . ': ' . $this->error);
         }
         if ($result === true) {
             return true;
         }
+        // TODO add `$this->showSqlBarPanel();` ? in order to display SQL statements?
         throw new Exception('Object answer on SQL statement (should have been true');
     }
 
@@ -150,9 +153,11 @@ class LogMysqli extends BackyardMysqli
         $result = $this->query($sql, $errorLogOutput, $logQuery);
 
         if ($result === false) {
+            // TODO add `$this->showSqlBarPanel();` ? in order to display SQL statements?
             throw new Exception($this->errno . ': ' . $this->error);
         }
         if ($result === true) {
+            // TODO add `$this->showSqlBarPanel();` ? in order to display SQL statements?
             throw new Exception('Non-object answer on SQL statement (unexpectedly equals true)');
         }
         return $result;
@@ -298,9 +303,11 @@ class LogMysqli extends BackyardMysqli
     {
         $query = $this->query($sql);
         if ($query === true) {
+            // TODO add `$this->showSqlBarPanel();` ? in order to display SQL statements?
             throw new Exception('SQL statement resulting in \mysqli_result<object> expected. True received.');
         }
         if (!$query) {
+            // TODO add `$this->showSqlBarPanel();` ? in order to display SQL statements?
             throw new Exception($this->errno . ': ' . $this->error);
         }
         $row = $query->fetch_assoc();
@@ -319,6 +326,7 @@ class LogMysqli extends BackyardMysqli
     public function fetchSingleString($sql)
     {
         $query = $this->fetchSingle($sql);
+        // TODO add `if(!is_string($query))$this->showSqlBarPanel();` ? in order to display SQL statements?
         Assert::string($query);
         return $query;
     }
@@ -338,6 +346,7 @@ class LogMysqli extends BackyardMysqli
             return null;
         }
         if (!is_array($arr)) {
+            // TODO add `$this->showSqlBarPanel();` ? in order to display SQL statements?
             throw new Exception('SQL statement resulting in non array.');
         }
         foreach ($arr as $name => $str) {
@@ -398,6 +407,7 @@ class LogMysqli extends BackyardMysqli
             $key = reset($row);
             $value = count($row) == 2 ? next($row) : $row;
             if (count($row) > 2) {
+                // TODO add `if(!is_array($value))$this->showSqlBarPanel();` ? in order to display SQL statements?
                 Assert::isArray($value);
                 array_shift($value);
             }

--- a/classes/MyCMS.php
+++ b/classes/MyCMS.php
@@ -50,7 +50,7 @@ class MyCMS extends MyCMSMonoLingual
     /**
      * Constructor
      *
-     * @param array<array<array<array<string>,bool,string>,string>|BackyardError|LogMysqli|null> $myCmsConf
+     * @param array<mixed> $myCmsConf
      */
     public function __construct(array $myCmsConf = [])
     {

--- a/classes/MyCMSMonoLingual.php
+++ b/classes/MyCMSMonoLingual.php
@@ -51,7 +51,7 @@ class MyCMSMonoLingual
     /**
      * Constructor
      *
-     * @param array<array<array<array<string>,bool,string>,string>|BackyardError|LogMysqli|null> $myCmsConf
+     * @param array<mixed> $myCmsConf
      * @throws Exception if logger not configured
      */
     public function __construct(array $myCmsConf = [])

--- a/classes/MyCMSMonoLingual.php
+++ b/classes/MyCMSMonoLingual.php
@@ -175,8 +175,9 @@ class MyCMSMonoLingual
     public function fetchAndReindexStrictArray($sql)
     {
         $result = $this->dbms->fetchAndReindex($sql); // array<array<string|null|array<string|null>>|string>|false
-        Debugger::barDump($sql, 'SQL statement for fetchAndReindex'); //temp
-        Debugger::barDump($result, 'Result of fetchAndReindex'); //temp
+        if (!is_array($result)) {
+            $this->dbms->showSqlBarPanel();
+        }
         Assert::isArray($result);
         if (empty($result)) {
             return [];

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "issues": "https://github.com/WorkOfStan/mycms/issues",
         "source": "https://github.com/WorkOfStan/mycms"
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "WorkOfStan\\MyCMS\\": ["classes/"]

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "nette/utils": "^2.4.8|^3.2.2",
         "texy/texy": "^2.7.1",
         "godsdev/tools": "^0.3.8",
-        "workofstan/backyard": "dev-feature/phpstan-testing-update",
+        "workofstan/backyard": "^3.3.1",
         "ext-session": "*",
         "ext-mbstring": "*"
     },
@@ -38,7 +38,7 @@
         "issues": "https://github.com/WorkOfStan/mycms/issues",
         "source": "https://github.com/WorkOfStan/mycms"
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true,
     "autoload": {
         "psr-4": {

--- a/dist/.htaccess
+++ b/dist/.htaccess
@@ -31,12 +31,9 @@ RedirectMatch 404 composer\.
 RedirectMatch 404 phpunit\.xml
 RedirectMatch 404 \.gitignore
 RedirectMatch 404 \.stylelintignore
-RedirectMatch 404 \.md$
 RedirectMatch 404 \/cache\/
 RedirectMatch 404 \/temp\/
 RedirectMatch 404 \/db\/
-RedirectMatch 404 \.yml$
-RedirectMatch 404 \.sh$
 RedirectMatch 404 classes\/
 RedirectMatch 404 Test\/
 RedirectMatch 404 \/logs\/
@@ -46,4 +43,8 @@ RedirectMatch 404 /\.sass-cache
 RedirectMatch 404 /package\.json
 RedirectMatch 404 /package\-lock\.json
 RedirectMatch 404 phpstan.neon.dist
+RedirectMatch 404 \.md$
+RedirectMatch 404 \.neon$
+RedirectMatch 404 \.sh$
+RedirectMatch 404 \.yml$
 #</IfModule>

--- a/dist/CHANGELOG.md
+++ b/dist/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Security` in case of vulnerabilities
 
 ## [0.1] - YYYY-MM-DD
-- new application based on MyCMS/0.4.4/dist
+- new application based on MyCMS/0.4.5/dist
 
 [Unreleased]: https://github.com/vendor/project/compare/v0.1...HEAD
 [0.1]: https://github.com/vendor/project/releases/tag/v0.1

--- a/dist/README.md
+++ b/dist/README.md
@@ -1,11 +1,11 @@
 # MYCMSPROJECTSPECIFIC
 XYZ web
-(Folder *dist* is an instant seed of a new project.)
+(Folder *dist* is an instant seed of a new project/application.)
 
 ## Stack
 
 Linux, Apache (mod_rewrite, mod_header, ssl...)
-PHP 7.0
+PHP 5.6, 7.x
 MySQL
 PHP libraries
 - xml

--- a/dist/classes/Admin.php
+++ b/dist/classes/Admin.php
@@ -353,7 +353,7 @@ class Admin extends MyAdmin
                 // TODO path was used in A project. Reconsider here.
                 // . ' WHERE LEFT(path, ' . PATH_MODULE . ')="'
                 // . $this->MyCMS->escapeSQL($this->MyCMS->SETTINGS['PATH_HOME']) . '" ORDER BY path');
-            \Tracy\Debugger::barDump($categories, 'CATEGORIES'); // temp
+            //\Tracy\Debugger::barDump($categories, 'CATEGORIES'); // temp
             $articles = $this->MyCMS->fetchAndReindexStrictArray('SELECT '
                 //. 'category_id,' // TODO category_id was used in A project to link content rows. Reconsider here.
                 . 'id,active,IF(content_' .
@@ -362,7 +362,7 @@ class Admin extends MyAdmin
                 FROM ' . TAB_PREFIX . 'content');
                 //. ' WHERE category_id > 0'); // TODO category_id was used in A project to link content rows.
                 //Reconsider here.
-            \Tracy\Debugger::barDump($categories, 'CATEGORIES'); // temp
+            //\Tracy\Debugger::barDump($categories, 'CATEGORIES'); // temp
             foreach ($categories as $key => $category) {
                 Assert::isArray($category);
                 /* TODO this code probably should display articles related to categories, Reconsider - Implement?

--- a/dist/classes/MyCMSProject.php
+++ b/dist/classes/MyCMSProject.php
@@ -35,7 +35,7 @@ class MyCMSProject extends MyCMS
     /**
      * Constructor
      *
-     * @param array<array<array<array<string>,bool,string>,string>|BackyardError|LogMysqli|null> $myCmsConf
+     * @param array<mixed> $myCmsConf
      */
     public function __construct(array $myCmsConf = [])
     {

--- a/dist/composer.json
+++ b/dist/composer.json
@@ -29,7 +29,7 @@
         "issues": "https://github.com/WorkOfStan/mycms/issues",
         "source": "https://github.com/WorkOfStan/mycms"
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true,
     "autoload": {
         "psr-4": {

--- a/dist/composer.json
+++ b/dist/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "require": {
         "php": "^5.6|^7.0",
-        "workofstan/mycms": "dev-feature/phpstan9",
+        "workofstan/mycms": "dev-feature/phpstan9-mixed",
         "robmorgan/phinx": "^0.10.6|^0.12.3",
         "swiftmailer/swiftmailer": "^5.4|^6.2",
         "webmozart/assert": "^1.9.1",

--- a/dist/composer.json
+++ b/dist/composer.json
@@ -29,7 +29,8 @@
         "issues": "https://github.com/WorkOfStan/mycms/issues",
         "source": "https://github.com/WorkOfStan/mycms"
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "WorkOfStan\\mycmsprojectnamespace\\": ["classes/"]

--- a/dist/composer.json
+++ b/dist/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "require": {
         "php": "^5.6|^7.0",
-        "workofstan/mycms": "dev-feature/phpstan9-mixed",
+        "workofstan/mycms": "dev-main",
         "robmorgan/phinx": "^0.10.6|^0.12.3",
         "swiftmailer/swiftmailer": "^5.4|^6.2",
         "webmozart/assert": "^1.9.1",


### PR DESCRIPTION
Added
- MyCMSMonoLingual::fetchAndReindexStrictArray displays the SQL bar panel in case of Assertion thrown Exception

Changed
- $myCmsConf is mixed[] (instead of complex and not future usage proof array<array<array<array<string>,bool,string>,string>|BackyardError|LogMysqli|null> ) For some fields, there is a runtime assertion.
- workofstan/backyard bumped to ^3.3.1