### PR TITLE
Backward compatibility fixed for language-xx.inc.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - dist: featureFlag `newletter_input_box` can turn off both the (un)subscribe email input box and the POST value processing
 
 ### Changed
+- **BREAKING CHANGE** dist/Test/AdminTest.php TableAdmin declaration expects language and prefixL10n
+- **BREAKING CHANGE** dist/Test/ControllerTest.php MUST accomodate language both in GET and _SESSION as the checks are stricter in L10n
 - App class handles the request dispatching instead of spagetti code in index.php
 - L10n (Localisation) class with loadLocalisation and translate methods common both for admin UI and MyCMS UI (instead of include php file with array for web UI and parsing yml for admin UI)
 - dist/Admin::sectionTranslations uses new L10n class instead of including language.inc.php file directly
 - MyAdminProcess::processTranslationsUpdate method created instead of code being spagetti part of dist/AdminProcess::adminProcess
 
 ### Deprecated
-- using dist/language-xx.inc.php files (conf/l10n/language-xx.yml will be used instead) - just resave admin.php?translations to transform to the new format (unless turned off by featureFlag 'languageFileWriteIncOnlyNotYml')
+- using dist/language-xx.inc.php files (conf/l10n/language-xx.yml will be used instead) - just add $myCmsConf['prefixL10n'] to config.php and resave admin.php?translations to transform to the new format (unless turned off by featureFlag 'languageFileWriteIncOnlyNotYml')
 
 ### Removed
 - Texy
@@ -41,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - yml style, add missing document start "---" (document-start); fix indentation
+- dist/footer.latte Colon as argument separator is deprecated, use comma instead
 
 ### Security
 - App class changes touched the CSRF mechanism, so CSRF was successfully tested

--- a/classes/L10n.php
+++ b/classes/L10n.php
@@ -143,7 +143,7 @@ class L10n
         $translationFile = $this->prefix . $language . '.yml';
 
         // expected to transform APP_DIR/conf/l10n/file into APP_DIR
-        $languageFile = ($this->prefix != '' ? dirname(dirname(dirname($this->prefix))) : DIR_TEMPLATE . '/../')
+        $languageFile = ($this->prefix != '' ? dirname(dirname(dirname($this->prefix))) : DIR_TEMPLATE . '/..')
             . '/language-' . $language . '.inc.php'; // deprecated
 
         if (file_exists($translationFile)) {

--- a/classes/L10n.php
+++ b/classes/L10n.php
@@ -143,7 +143,8 @@ class L10n
         $translationFile = $this->prefix . $language . '.yml';
 
         // expected to transform APP_DIR/conf/l10n/file into APP_DIR
-        $languageFile = dirname(dirname(dirname($this->prefix))) . '/language-' . $language . '.inc.php'; // deprecated
+        $languageFile = ($this->prefix != '' ? dirname(dirname(dirname($this->prefix))) : DIR_TEMPLATE . '/../')
+            . '/language-' . $language . '.inc.php'; // deprecated
 
         if (file_exists($translationFile)) {
             $tempYaml = Yaml::parseFile($translationFile);

--- a/classes/MyTableLister.php
+++ b/classes/MyTableLister.php
@@ -63,6 +63,12 @@ class MyTableLister
     /** @var array<array> all tables in the database */
     public $tables;
 
+    /**
+     * @var array<string> Selected locale strings
+     * DEPRECATED keep this declaration just for backward compatibility
+     */
+    public $TRANSLATION = [];
+
     /** @var array<string> Available languages for MyCMS */
     public $TRANSLATIONS = [];
 

--- a/classes/MyTableLister.php
+++ b/classes/MyTableLister.php
@@ -109,7 +109,11 @@ class MyTableLister
         $this->getTables();
         $this->setTable($table);
         $this->rand = rand((int) 1e5, (int) (1e6 - 1));
-        Assert::string($options['prefixL10n']);
+        if (array_key_exists('prefixL10n', $options)) { // the condition is due to a deprecated backward compatibility
+            Assert::string($options['prefixL10n']); // only this line is relevant
+        } else {
+            $options['prefixL10n'] = '';
+        }
         Assert::isArray($options['TRANSLATIONS']);
         $this->TRANSLATIONS = $options['TRANSLATIONS'];
         $this->localisation = new L10n($options['prefixL10n'], $this->TRANSLATIONS);

--- a/dist/Test/ControllerTest.php
+++ b/dist/Test/ControllerTest.php
@@ -41,7 +41,7 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
         error_reporting(E_ALL); // incl E_NOTICE
         Debugger::enable(Debugger::DEVELOPMENT, __DIR__ . '/../log');
         $backyard = new Backyard($backyardConf);
-        if(!defined('DB_HOST')){
+        if (!defined('DB_HOST')) {
             // if set-up of constants didn't happen in the first test according to alphabet
             new \WorkOfStan\MyCMS\InitDatabase('testing', __DIR__ . '/../');
         }
@@ -97,8 +97,7 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
             'httpMethod' => 'GET',
             'session' => $_SESSION,
             'get' => $this->get,
-            ]
-        );
+            ]);
         $controller = $this->object->run();
         $this->assertArraySubset(['template' => 'home', 'context' => []], $controller);
     }
@@ -115,8 +114,7 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
             'httpMethod' => 'GET',
             'session' => $_SESSION,
             'get' => $this->get,
-            ]
-        );
+            ]);
         $this->assertArraySubset(
             ['template' => 'home', 'context' => $this->myCms->context],
             $this->object->run()

--- a/dist/Test/ControllerTest.php
+++ b/dist/Test/ControllerTest.php
@@ -65,7 +65,7 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
         $this->myCms = new MyCMSProject($mycmsOptions);
 
         // set language in $_SESSION and $this->get as one of the TRANSLATIONS array above
-        // this is equivalent to go the other language homepage from the DEFAULT_LANGUAGE homepage
+        // this settings is equivalent to going to another language homepage from the DEFAULT_LANGUAGE homepage
         $this->get = ['language' => 'en'];
         $_SESSION = ['language' => 'en']; // because $_SESSION is not defined in the PHPUnit mode
         $this->language = $_SESSION['language'] = $this->myCms->getSessionLanguage($this->get, $_SESSION, false);

--- a/dist/Test/ControllerTest.php
+++ b/dist/Test/ControllerTest.php
@@ -12,18 +12,21 @@ require_once __DIR__ . '/../conf/config.php';
 
 /**
  * Tests of Controller (of MVC)
- * (Last MyCMS/dist revision: 2022-03-05, v0.4.6)
+ * (Last MyCMS/dist revision: 2022-03-06, v0.4.6)
  */
 class ControllerTest extends \PHPUnit_Framework_TestCase
 {
+    /** @var mixed[] */
+    protected $get;
+
+    /** @var string */
+    protected $language;
+
     /** @var MyCMSProject */
     protected $myCms;
 
     /** @var Controller */
     protected $object;
-
-    /** @var string */
-    protected $language;
 
     /**
      * Sets up the fixture, for example, opens a network connection.
@@ -38,6 +41,10 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
         error_reporting(E_ALL); // incl E_NOTICE
         Debugger::enable(Debugger::DEVELOPMENT, __DIR__ . '/../log');
         $backyard = new Backyard($backyardConf);
+        if(!defined('DB_HOST')){
+            // if set-up of constants didn't happen in the first test according to alphabet
+            new \WorkOfStan\MyCMS\InitDatabase('testing', __DIR__ . '/../');
+        }
         $mycmsOptions = [
             // constants are defined by `new InitDatabase` in the alphabetically first test
             'dbms' => new LogMysqli(
@@ -51,20 +58,17 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
             'prefixL10n' => __DIR__ . '/../conf/l10n/language-',
             'templateAssignementParametricRules' => [],
             'TRANSLATIONS' => [
-                'cs' => 'Česky', // todo remove this line with DEFAULT_LANGUAGE and
-                // fix the MyFriendlyUrl.php:207 Arg #2 not an array
-                // and WorkOfStan\mycmsprojectnamespace\Test\ControllerTest::testControllerContext
-                // Webmozart\Assert\InvalidArgumentException: Expected one of: "en", "zh". Got: "cs"
                 'en' => 'English',
                 'zh' => '中文',
             ],
         ];
         $this->myCms = new MyCMSProject($mycmsOptions);
-        $get = []; // ['language' => 'en']; TODO use this definition when cs above removed
 
-        // set language as one of the TRANSLATIONS array above 'language' => 'en'
-        $_SESSION = []; // because $_SESSION is not defined in the PHPUnit mode
-        $this->language = $_SESSION['language'] = $this->myCms->getSessionLanguage($get, $_SESSION, false);
+        // set language in $_SESSION and $this->get as one of the TRANSLATIONS array above
+        // this is equivalent to go the other language homepage from the DEFAULT_LANGUAGE homepage
+        $this->get = ['language' => 'en'];
+        $_SESSION = ['language' => 'en']; // because $_SESSION is not defined in the PHPUnit mode
+        $this->language = $_SESSION['language'] = $this->myCms->getSessionLanguage($this->get, $_SESSION, false);
 
         //according to what you test, change $this->myCms->context before invoking
         //$this->object = new Controller; within Test methods
@@ -88,7 +92,13 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testControllerNoContext()
     {
-        $this->object = new Controller($this->myCms, ['language' => $this->language, 'httpMethod' => 'GET']);
+        $this->object = new Controller($this->myCms, [
+            'language' => $this->language,
+            'httpMethod' => 'GET',
+            'session' => $_SESSION,
+            'get' => $this->get,
+            ]
+        );
         $controller = $this->object->run();
         $this->assertArraySubset(['template' => 'home', 'context' => []], $controller);
     }
@@ -101,7 +111,12 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
     public function testControllerContext()
     {
         $this->myCms->context = ['1' => '2', '3' => '4', 'c'];
-        $this->object = new Controller($this->myCms, ['httpMethod' => 'GET']);
+        $this->object = new Controller($this->myCms, [
+            'httpMethod' => 'GET',
+            'session' => $_SESSION,
+            'get' => $this->get,
+            ]
+        );
         $this->assertArraySubset(
             ['template' => 'home', 'context' => $this->myCms->context],
             $this->object->run()
@@ -116,10 +131,11 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
     public function testControllerAbout()
     {
         $this->object = new Controller($this->myCms, [
-            'get' => [
+            'get' => array_merge($this->get, [
                 'about' => '',
-            ],
+            ]),
             'httpMethod' => 'GET',
+            'session' => $_SESSION,
         ]);
         $controller = $this->object->run();
         $this->assertArrayHasKey('template', $controller);

--- a/dist/template/footer.latte
+++ b/dist/template/footer.latte
@@ -1,4 +1,4 @@
-<footer class="footer">
+{* (Last MyCMS/dist revision: 2022-03-06, v0.4.6) *}<footer class="footer">
     <div class="footer__nav">
         <div class="container">
             <ul>
@@ -16,10 +16,10 @@
                 <input type="email" name="newsletter" id="newsletter-email" placeholder="{="Zde uveďte Vaši e-mailovou adresu"|translate}" required>
                 <input type="hidden" name="token" value="{$token}">
                 <div class="submit-form">
-                    <span><span>{="By subscribing you agree to our handling of your {personal data}."|translate|replace:'{':'<a href="?page=personal-data" target="_blank">'|replace:'}':'</a>'|noescape}</span></span>
+                    <span><span>{="By subscribing you agree to our handling of your {personal data}."|translate|replace:'{','<a href="?page=personal-data" target="_blank">'|replace:'}','</a>'|noescape}</span></span>
                     <button type="submit" class="button--red">{="Subscribe"|translate}</button>
                 </div>
-                <span class="only-mobile">{="By subscribing you agree to our handling of your {personal data}."|translate|replace:'{':'<a href="?page=personal-data" target="_blank">'|replace:'}':'</a>'|noescape}</span>
+                <span class="only-mobile">{="By subscribing you agree to our handling of your {personal data}."|translate|replace:'{','<a href="?page=personal-data" target="_blank">'|replace:'}','</a>'|noescape}</span>
             </form>
 
         </div>


### PR DESCRIPTION
- backward compatibility fixed for language-xx.inc.php files and **BREAKING CHANGES** in PHPUnit tests described
- fix dist/footer.latte Colon as argument separator is deprecated, use comma instead
