### PR TITLE
Admin Navigation in Latte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Latte inheritance test pages (inheritance-*.latte added where new include inherite.latte is demonstrated) including PHPUnit FriendlyUrlTest::testPageStatusOverHttp
 - instead of simply {include $latte} call {include 'inherite.latte', latte => $latte} so that the preferred existing version of latte is used
 - new parameter to MyCustomFilters allows for another translate method (in order to use $tableAdmin->translate instead of $MyCMS->translate for Admin UI)
+- featureFlags to admin-*.latte
 
 ### `Changed` for changes in existing functionality
 - MyCommon::verboseBarDump Dumper::LOCATION => false hides where the dump originated as this is not the original place anyway, show it in the title instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MyCommon::verboseBarDump Dumper::LOCATION => false hides where the dump originated as this is not the original place anyway, show it in the title instead
 - nicer formatting Admin UI table SQL statement
 - Logging of untranslated strings when DEBUG_VERBOSE into `'log/translation_missing_' . date("Y-m-d") . '.log'` (instead of swelling translation_missing.log)
-- Admin UI can be rendered by Latte (instead directly from MyAdmin methods) if $featureFlags['admin_latte_render'] set to true (still experimental because library vs app references MUST be solved)
+- Admin UI can be rendered by Latte (instead directly from MyAdmin methods) if $featureFlags['admin_latte_render'] set to true (still experimental because main part of body is prerendered as HTML)
 - Admin UI in Latte mode receives params including token and authUser (0=anonymous, 1=logged-in)
 - **BREAKING CHANGE (feature flagged)** if $featureFlags['admin_latte_render']===false `dist/styles/admin.css.php` MUST be present (to link rel `admin.css` deep in vendor folder) and admin.php code has to be updated to alternatively use the latte rendering
 - Default Latte templates moved from app part of templates to library part of templates in order to quickly deploy. If you start working with the templates however, you should maintain them in the app folder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - relax dist/FriendlyUrl::switchParametric - if there's no rule to produce a friendly URL, don't report error not changing it, only an info
 - dist/composer.json: Keeps packages sorted by name when adding new one
 - GitHub Actions: only use cache with an exact key hit
+- MyAdmin::renderAdmin() $switches as parameter of Latté instead of working with $_GET in the template
 
 ### `Deprecated` for soon-to-be removed features
 - dist/rector.php (TODO consider using just string replace instead of the rector engine)
-- Admin UI in Latte mode doesn't use Admin::outputImageSelector and/or Admin::outputFooter, so before turning on the Admin Latte, move the custom code to the corresponding lattes
+- Admin UI in Latte mode doesn't use Admin::endAdmin(), Admin::getAdminCss(), Admin::outputAdmin(), Admin::outputBodyEnd(), Admin::outputFooter(), Admin::outputHead(), Admin::outputImageSelector(), Admin::outputNavigation(), Admin::outputSpecialMenuLinks(), Admin::outputSpecialSettingsLinks(), so before turning on the Admin Latte, move the custom code to the corresponding lattes
 
 ### `Removed` for now removed features
 - attributes type and charset (as in `<script type="text/javascript" src="scripts/admin.js?v=1" charset="utf-8">`) are obsolete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Logging of untranslated strings when DEBUG_VERBOSE into monthly rotating `'log/translation_missing_' . date("Y-m") . '.log'` (instead of one big swelling translation_missing.log)
 - Admin UI can be rendered by Latte (instead directly from MyAdmin methods) if $featureFlags['admin_latte_render'] set to true (still experimental because main part of body is prerendered as HTML)
 - Admin UI in Latte mode receives params including token and authUser (0=anonymous, 1=logged-in)
-- **BREAKING CHANGE (feature flagged)** if $featureFlags['admin_latte_render']===false `dist/styles/admin.css.php` MUST be present (to link rel `admin.css` deep in vendor folder) and admin.php code has to be updated to alternatively use the latte rendering
+- **BREAKING CHANGE (feature flagged)** if $featureFlags['admin_latte_render']===false `dist/styles/admin.css.php` MUST be present (to link rel `admin.css` deep in vendor folder) and admin.php code has to be updated to alternatively use the latte rendering and toggle admin menu special links
 - Default Latte templates moved from app part of templates to library part of templates in order to quickly deploy. If you start working with the templates however, you should maintain them in the app folder.
 - color highlighting of sections of scripts build.sh and phpstan.sh
 - relax dist/FriendlyUrl::switchParametric - if there's no rule to produce a friendly URL, don't report error not changing it, only an info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Changed` for changes in existing functionality
 - MyCommon::verboseBarDump Dumper::LOCATION => false hides where the dump originated as this is not the original place anyway, show it in the title instead
 - nicer formatting Admin UI table SQL statement
-- Logging of untranslated strings when DEBUG_VERBOSE into `'log/translation_missing_' . date("Y-m-d") . '.log'` (instead of swelling translation_missing.log)
+- Logging of untranslated strings when DEBUG_VERBOSE into monthly rotating `'log/translation_missing_' . date("Y-m") . '.log'` (instead of one big swelling translation_missing.log)
 - Admin UI can be rendered by Latte (instead directly from MyAdmin methods) if $featureFlags['admin_latte_render'] set to true (still experimental because main part of body is prerendered as HTML)
 - Admin UI in Latte mode receives params including token and authUser (0=anonymous, 1=logged-in)
 - **BREAKING CHANGE (feature flagged)** if $featureFlags['admin_latte_render']===false `dist/styles/admin.css.php` MUST be present (to link rel `admin.css` deep in vendor folder) and admin.php code has to be updated to alternatively use the latte rendering

--- a/README.md
+++ b/README.md
@@ -279,3 +279,4 @@ new Controller(['requestUri' => $_SERVER['REQUEST_URI']])
 
 ### TODO SECURITY
 * 190723: pokud jsou v té samé doméně dvě různé instance MyCMS, tak přihlášením do jednoho admin.php jsem přihlášen do všech, i když ten uživatel tam ani neexistuje
+* 220513, Latte::2.11.3 Notice: Engine::addFilter(null, ...) is deprecated, use addFilterLoader() since ^2.10.8 which requires php: >=7.1 <8.2

--- a/classes/L10n.php
+++ b/classes/L10n.php
@@ -90,7 +90,7 @@ class L10n
                 error_log(
                     '[' . date("d-M-Y H:i:s") . '] ' . $this->selectedLanguage . '\\' . $key . PHP_EOL,
                     3,
-                    'log/translation_missing_' . date("Y-m-d") . '.log'
+                    'log/translation_missing_' . date("Y-m") . '.log'
                 );
             }
         }

--- a/classes/Latte/MyCustomFilters.php
+++ b/classes/Latte/MyCustomFilters.php
@@ -67,7 +67,8 @@ class MyCustomFilters
      * TODO: requires latte/latte::^2.10.8 which requires php: >=7.1 <8.2
      *
      * @param string $filter
-     * @return callable|null
+     * @ todo return callable|null
+     * @return array<$this|string>|null
      */
     public function loader(string $filter) //: ?callable
     {

--- a/classes/Latte/MyCustomFilters.php
+++ b/classes/Latte/MyCustomFilters.php
@@ -41,6 +41,8 @@ class MyCustomFilters
      *
      * @param string $filter
      * @param mixed $value
+     * @deprecated 0.4.7 Latte::2.11.3 Notice: Engine::addFilter(null, ...) is deprecated, use addFilterLoader()
+     * @see self::loader()
      * @return string|void
      */
     public function common($filter, $value)
@@ -57,6 +59,22 @@ class MyCustomFilters
             Assert::string($result);
             return $result;
         }
+    }
+
+    /**
+     * Filter loader expected by $latte->addFilterLoader()
+     * @see https://latte.nette.org/en/develop#toc-filter-loaders
+     * TODO: requires latte/latte::^2.10.8 which requires php: >=7.1 <8.2
+     *
+     * @param string $filter
+     * @return callable|null
+     */
+    public function loader(string $filter) //: ?callable
+    {
+        if (method_exists($this, $filter)) {
+            return [$this, $filter];
+        }
+        return null;
     }
 
     /**

--- a/classes/MyAdmin.php
+++ b/classes/MyAdmin.php
@@ -914,7 +914,6 @@ class MyAdmin extends MyCommon
             ]
         );
         $htmlbody = $this->outputAdminBody(); // MUST precede outputBodyEndInlineScript method so that $this->tableAdmin->script is already populated
-   //     $switches = [];
         $params = array_merge($this->renderParams, [
             'authUser' => (int) (isset($_SESSION['user']) && $_SESSION['user']), // 0 vs 1
             'clientSideResources' => $this->clientSideResources,
@@ -926,14 +925,13 @@ class MyAdmin extends MyCommon
             'language' => Tools::h($_SESSION['language']),
             'pageTitle' => $this->getPageTitle(),
             'searchString' => (isset($_GET['search']) && $_GET['search']) ? $_GET['search'] : '',
-            //'switches' => $switches,
             'token' => end($_SESSION['token']), // for login
             'translations' => $this->tableAdmin->TRANSLATIONS, // languages for which translations are available
             'username' => (isset($_SESSION['user']) && $_SESSION['user']) ? $_SESSION['user'] : null,
         ]);
         // Inherites switches
-        if(!array_key_exists('switches', $params)){
-            $params['switches']=[];
+        if (!array_key_exists('switches', $params)) {
+            $params['switches'] = [];
         }
         // test for presence of a string in_array is simpler than testing for existance and value of a boolean array
         foreach (['change-password', 'create-user', 'delete-user', 'logout', 'media', 'user'] as $switch) {

--- a/classes/MyAdmin.php
+++ b/classes/MyAdmin.php
@@ -943,6 +943,7 @@ class MyAdmin extends MyCommon
             }
         }
         $customFilters = new MyCustomFilters($this->MyCMS, [$this->tableAdmin, 'translate']);
+        // TODO use [$customFilters, 'loader'] with $Latte->addFilterLoader($this->customFilters)
         $render = new Render($this->template, DIR_TEMPLATE_CACHE, [$customFilters, 'common']);
         $render->renderLatte($params);
         $this->MyCMS->dbms->showSqlBarPanel();

--- a/classes/MyAdmin.php
+++ b/classes/MyAdmin.php
@@ -927,6 +927,7 @@ class MyAdmin extends MyCommon
             'HTMLHeaders' => $this->HTMLHeaders,
             'language' => Tools::h($_SESSION['language']),
             'pageTitle' => $this->getPageTitle(),
+            'searchString' => (isset($_GET['search']) && $_GET['search']) ? $_GET['search'] : '',
             'switches' => $switches,
             'token' => end($_SESSION['token']), // for login
             'translations' => $this->tableAdmin->TRANSLATIONS, // languages for which translations are available
@@ -945,9 +946,13 @@ class MyAdmin extends MyCommon
      */
     private function outputAdminBody()
     {
-        $output = '<header>'
-            . $this->outputNavigation()
-            . '</header>' . PHP_EOL . '<div class="container-fluid row">' . PHP_EOL;
+        $output = '';
+        if (!Tools::nonzero($this->featureFlags['admin_latte_render'])) {
+            $output .= '<header>'
+                . $this->outputNavigation()
+                . '</header>' . PHP_EOL;
+        }
+        $output .= '<div class="container-fluid row">' . PHP_EOL;
         if (isset($_SESSION['user']) && $_SESSION['user']) {
             $output .= '<a href="#" id="v-divider"></a>';
             $output .= '<nav class="col-md-3 bg-light sidebar order-last" id="admin-sidebar">'

--- a/classes/MyAdmin.php
+++ b/classes/MyAdmin.php
@@ -108,8 +108,8 @@ class MyAdmin extends MyCommon
 
     /**
      * Ends Admin rendering with TracyPanels
-     * LEGACY
      *
+     * @deprecated 0.4.7 Set `$featureFlags['admin_latte_render'] = true;` instead.
      * @return void
      */
     public function endAdmin()
@@ -123,8 +123,8 @@ class MyAdmin extends MyCommon
     /**
      * As vendor folder has usually denied access from browser,
      * the content of the standard admin.css MUST be available through this method
-     * LEGACY
      *
+     * @deprecated 0.4.7 Set `$featureFlags['admin_latte_render'] = true;` instead.
      * @return string
      */
     public function getAdminCss()
@@ -134,8 +134,9 @@ class MyAdmin extends MyCommon
 
     /**
      * Output (in HTML) the <head> section of admin
-     * LEGACY
      *
+     * @deprecated 0.4.7 Set `$featureFlags['admin_latte_render'] = true;` instead.
+     * @see template/admin-head.latte
      * @param string $title used in <title>
      * @return string
      */
@@ -225,6 +226,8 @@ class MyAdmin extends MyCommon
     /**
      * Output (in HTML) the project-specific links in the navigation section of admin
      *
+     * @deprecated 0.4.7 Set `$featureFlags['admin_latte_render'] = true;` instead.
+     * @see template/admin-special-menu-links.latte
      * @return string
      */
     protected function outputSpecialMenuLinks()
@@ -235,6 +238,8 @@ class MyAdmin extends MyCommon
     /**
      * Output (in HTML) the project-specific links in the settings section of admin
      *
+     * @deprecated 0.4.7 Set `$featureFlags['admin_latte_render'] = true;` instead.
+     * @see template/admin-special-settings-links.latte
      * @return string
      */
     protected function outputSpecialSettingsLinks()
@@ -494,8 +499,9 @@ class MyAdmin extends MyCommon
      * Output (in HTML) the end part of administration page.
      * It's a list of scripts and an inline script
      * This method also modifies $this->script.  (Todo ??? Really)
-     * LEGACY
      *
+     * @deprecated 0.4.7 Set `$featureFlags['admin_latte_render'] = true;` instead.
+     * @see template/@admin.latte
      * @return string
      */
     protected function outputBodyEnd()
@@ -523,8 +529,9 @@ class MyAdmin extends MyCommon
 
     /**
      * Output (in HTML) the Bootstrap dialog for ImageSelector
-     * LEGACY
      *
+     * @deprecated 0.4.7 Set `$featureFlags['admin_latte_render'] = true;` instead.
+     * @see template/admin-output-image-selector.latte
      * @return string
      */
     protected function outputImageSelector()
@@ -605,8 +612,9 @@ class MyAdmin extends MyCommon
 
     /**
      * Output (in HTML) the admin's layout footer
-     * LEGACY
      *
+     * @deprecated 0.4.7 Set `$featureFlags['admin_latte_render'] = true;` instead.
+     * @see template/@admin.latte
      * @return string
      */
     protected function outputFooter()
@@ -974,7 +982,6 @@ class MyAdmin extends MyCommon
 
     /**
      * Return the HTML output of the complete administration page.
-     * Legacy - being redone as renderAdmin using Latte
      *
      * Expected global variables:
      * * $_GET
@@ -986,6 +993,8 @@ class MyAdmin extends MyCommon
      * * TAB_PREFIX
      * * EXPAND_INFIX
      *
+     * @deprecated 0.4.7 Set `$featureFlags['admin_latte_render'] = true;` instead.
+     * @see MyAdmin::renderAdmin()
      * @return string
      */
     public function outputAdmin()

--- a/classes/MyAdmin.php
+++ b/classes/MyAdmin.php
@@ -172,6 +172,8 @@ class MyAdmin extends MyCommon
     /**
      * Output (in HTML) the navigation section of admin
      *
+     * @deprecated 0.4.7 Set `$featureFlags['admin_latte_render'] = true;` instead.
+     * @see template/admin-navigation.latte
      * @return string
      */
     protected function outputNavigation()
@@ -978,7 +980,7 @@ class MyAdmin extends MyCommon
         (isset($_SESSION['user']) && Tools::set($_GET['search'])) {
             $output .= $this->outputSearchResults($_GET['search']);
         }
-        // table listing/editing - TODO even for unlogged???
+        // table listing/editing - for unlogged reset in prepareAdmin()
         if ($_GET['table']) {
             $output .= $this->outputTable();
         } elseif (isset($_GET['media'])) { // media upload etc.

--- a/classes/MyAdmin.php
+++ b/classes/MyAdmin.php
@@ -65,6 +65,9 @@ class MyAdmin extends MyCommon
         'author' => '',
     ];
 
+    /** @var array<mixed> parameters for rendering set outside */
+    protected $renderParams = [];
+
     /**
      * @var array<array<string>> tables and columns to search in admin
      * table => [id, field1 to be searched in, field2 to be searched in...]
@@ -909,15 +912,8 @@ class MyAdmin extends MyCommon
             ]
         );
         $htmlbody = $this->outputAdminBody(); // MUST precede outputBodyEndInlineScript method so that $this->tableAdmin->script is already populated
-        $switches = [];
-        // test for presence of a string in_array is simpler than testing for existance and value of a boolean array
-        foreach (['change-password', 'create-user', 'delete-user', 'logout', 'media', 'user'] as $switch) {
-            // todo $_GET be replaced by an object property
-            if (isset($_GET[$switch])) {
-                $switches[] = $switch;
-            }
-        }
-        $params = [
+   //     $switches = [];
+        $params = array_merge($this->renderParams, [
             'authUser' => (int) (isset($_SESSION['user']) && $_SESSION['user']), // 0 vs 1
             'clientSideResources' => $this->clientSideResources,
             'inlineJavaScript' => $this->outputBodyEndInlineScript(),
@@ -928,11 +924,22 @@ class MyAdmin extends MyCommon
             'language' => Tools::h($_SESSION['language']),
             'pageTitle' => $this->getPageTitle(),
             'searchString' => (isset($_GET['search']) && $_GET['search']) ? $_GET['search'] : '',
-            'switches' => $switches,
+            //'switches' => $switches,
             'token' => end($_SESSION['token']), // for login
             'translations' => $this->tableAdmin->TRANSLATIONS, // languages for which translations are available
             'username' => (isset($_SESSION['user']) && $_SESSION['user']) ? $_SESSION['user'] : null,
-        ];
+        ]);
+        // Inherites switches
+        if(!array_key_exists('switches', $params)){
+            $params['switches']=[];
+        }
+        // test for presence of a string in_array is simpler than testing for existance and value of a boolean array
+        foreach (['change-password', 'create-user', 'delete-user', 'logout', 'media', 'user'] as $switch) {
+            // todo $_GET be replaced by an object property
+            if (isset($_GET[$switch])) {
+                $params['switches'][] = $switch;
+            }
+        }
         $customFilters = new MyCustomFilters($this->MyCMS, [$this->tableAdmin, 'translate']);
         $render = new Render($this->template, DIR_TEMPLATE_CACHE, [$customFilters, 'common']);
         $render->renderLatte($params);

--- a/classes/MyAdmin.php
+++ b/classes/MyAdmin.php
@@ -909,16 +909,28 @@ class MyAdmin extends MyCommon
             ]
         );
         $htmlbody = $this->outputAdminBody(); // MUST precede outputBodyEndInlineScript method so that $this->tableAdmin->script is already populated
+        $switches = [];
+        // test for presence of a string in_array is simpler than testing for existance and value of a boolean array
+        foreach (['change-password', 'create-user', 'delete-user', 'logout', 'media', 'user'] as $switch) {
+            // todo $_GET be replaced by an object property
+            if (isset($_GET[$switch])) {
+                $switches[] = $switch;
+            }
+        }
         $params = [
             'authUser' => (int) (isset($_SESSION['user']) && $_SESSION['user']), // 0 vs 1
             'clientSideResources' => $this->clientSideResources,
             'inlineJavaScript' => $this->outputBodyEndInlineScript(),
+            'featureFlags' => $this->featureFlags,
             'htmlbody' => $htmlbody,
             //'htmlhead' => $this->outputHead($this->getPageTitle()),
             'HTMLHeaders' => $this->HTMLHeaders,
             'language' => Tools::h($_SESSION['language']),
             'pageTitle' => $this->getPageTitle(),
+            'switches' => $switches,
             'token' => end($_SESSION['token']), // for login
+            'translations' => $this->tableAdmin->TRANSLATIONS, // languages for which translations are available
+            'username' => (isset($_SESSION['user']) && $_SESSION['user']) ? $_SESSION['user'] : null,
         ];
         $customFilters = new MyCustomFilters($this->MyCMS, [$this->tableAdmin, 'translate']);
         $render = new Render($this->template, DIR_TEMPLATE_CACHE, [$customFilters, 'common']);

--- a/classes/MyController.php
+++ b/classes/MyController.php
@@ -15,30 +15,6 @@ use WorkOfStan\MyCMS\Tracy\BarPanelTemplate;
  */
 class MyController extends MyCommon
 {
-    /** @var array<string|int|array> */
-    protected $result;
-
-    /**
-     * accepted attributes:
-     */
-
-    /**
-     * HTTP request parameters
-     *
-     * @var array<mixed>
-     * TBD: or is GET really always?? array<string|array<RECURSIVE>|int>
-     */
-    protected $get;
-
-    /** @var string */
-    protected $language = DEFAULT_LANGUAGE;
-
-    /** @var string */
-    protected $requestUri = ''; //default is homepage
-
-    /** @var array<array|string> */
-    protected $session;
-
     /**
      * Friendly URL instance MAY be passsed from project Controller.
      * It is eventually instantiated in Controller in order to use project specific methods.
@@ -46,13 +22,27 @@ class MyController extends MyCommon
      * @var MyFriendlyUrl
      */
     protected $friendlyUrl;
-
     /**
      * Whether Friendly URL is set and instanceof MyFriendlyUrl
      *
      * @var bool
      */
     protected $friendlyUrlInstantiated;
+    /**
+     * HTTP request parameters
+     *
+     * @var array<mixed>
+     * TBD: or is GET really always?? array<string|array<RECURSIVE>|int>
+     */
+    protected $get;
+    /** @var string */
+    protected $language = DEFAULT_LANGUAGE;
+    /** @var string */
+    protected $requestUri = ''; //default is homepage
+    /** @var array<string|int|array> */
+    protected $result;
+    /** @var array<array|string> */
+    protected $session;
 
     /**
      *
@@ -98,6 +88,8 @@ class MyController extends MyCommon
      * $this->prepareTemplate($options);
      * $this->prepareAllTemplates($options);
      *
+     * @deprecated 0.4.0
+     * @see MyController::run()
      * @return array<string|int|array>
      */
     public function controller()

--- a/classes/Render.php
+++ b/classes/Render.php
@@ -62,8 +62,7 @@ class Render
     public function renderLatte(array $params)
     {
         $displayParams = $params;
-        // TODO till the Admin UI isn't done properly hide HTML handed over in a variable
-        //unset($displayParams['htmlhead']);
+        // TODO hide HTML handed over in a variable till the Admin UI isn't done properly
         unset($displayParams['htmlbody']);
         Debugger::getBar()->addPanel(new BarPanelTemplate('Template: ' . $this->template, $displayParams));
         if (isset($_SESSION['user'])) {
@@ -73,10 +72,11 @@ class Render
         }
         $Latte = new \Latte\Engine();
         $Latte->setTempDirectory($this->dirTemplateCache);
-        $Latte->addFilter(null, $this->customFilters);
+        $Latte->addFilter(null, $this->customFilters); // TODO replace addFilter by addFilterLoader below:
+//        $Latte->addFilterLoader($this->customFilters); // requires latte/latte::^2.10.8 which requires php: >=7.1 <8.2
         Debugger::barDump($params, 'Params');
         Debugger::barDump($_SESSION, 'Session'); // mainly for $_SESSION['language']
-        $Latte->render($this->getTemplateFile(), $params); // @todo make template source configurable
+        $Latte->render($this->getTemplateFile(), $params);
         unset($_SESSION['messages']);
     }
 }

--- a/dist/README.md
+++ b/dist/README.md
@@ -303,6 +303,8 @@ Note: assets expects only ONE sub-level.
 ### Admin UI
 Add protected functions to Admin.php according to MyAdmin.php in order to add menu relevant for the application, such as Translations, FriendlyURL, Divisions and products, etc.
 
+Menu items can be toggled in `$switch` section of `admin.php`
+
 ### Redirector
 
 Note: Both the `old_url` and `new_url` MUST start with `/`.

--- a/dist/admin.php
+++ b/dist/admin.php
@@ -2,7 +2,7 @@
 
 /**
  * Admin
- * (Last MyCMS/dist revision: 2022-03-05, v0.4.6)
+ * (Last MyCMS/dist revision: 2022-05-13, v0.4.6+)
  */
 
 use Tracy\Debugger;
@@ -93,7 +93,7 @@ $admin = new Admin($MyCMS, [
     'featureFlags' => $featureFlags,
     'prefixUiL10n' => $myCmsConf['prefixL10n'],
     // Todo conf-admin.php once the MyAdmin is in Latte - based on config.php settings?
-    'renderParams' => ['switches' => ['pages', 'products', 'translations', 'urls']],
+    'renderParams' => ['switches' => ['divisions-products', 'pages', 'products', 'translations', 'urls']],
     'tableAdmin' => $tableAdmin,
     // to replace default CSS and/or JS in admin.php, uncomment the array below
 //    'clientSideResources' => [

--- a/dist/admin.php
+++ b/dist/admin.php
@@ -92,6 +92,8 @@ $admin = new Admin($MyCMS, [
     'agendas' => $AGENDAS,
     'featureFlags' => $featureFlags,
     'prefixUiL10n' => $myCmsConf['prefixL10n'],
+    // Todo conf-admin.php once the MyAdmin is in Latte - based on config.php settings?
+    'renderParams' => ['switches' => ['pages', 'products', 'translations', 'urls']],
     'tableAdmin' => $tableAdmin,
     // to replace default CSS and/or JS in admin.php, uncomment the array below
 //    'clientSideResources' => [

--- a/dist/admin.php
+++ b/dist/admin.php
@@ -88,12 +88,14 @@ if (isset($_POST) && is_array($_POST) && !empty($_POST)) {
     ]);
     $adminProcess->adminProcess($_POST);
 }
-$admin = new Admin($MyCMS, [
+$params = [
     'agendas' => $AGENDAS,
     'featureFlags' => $featureFlags,
     'prefixUiL10n' => $myCmsConf['prefixL10n'],
-    // Todo conf-admin.php once the MyAdmin is in Latte - based on config.php settings?
-    'renderParams' => ['switches' => ['divisions-products', 'pages', 'products', 'translations', 'urls']],
+    // Todo conf-admin.php once the MyAdmin is fully in Latte - default values based on config.php settings?
+    'renderParams' => [
+//        'switches' => []
+        ],
     'tableAdmin' => $tableAdmin,
     // to replace default CSS and/or JS in admin.php, uncomment the array below
 //    'clientSideResources' => [
@@ -102,7 +104,13 @@ $admin = new Admin($MyCMS, [
 //        'js' => [
 //        ]
 //    ]
-    ]);
+];
+foreach (['divisions-products', 'pages', 'products', 'translations', 'urls'] as $switch) {
+    if (isset($_GET[$switch])) {
+        $params['renderParams']['switches'][] = $switch;
+    }
+}
+$admin = new Admin($MyCMS, $params);
 if (isset($featureFlags['admin_latte_render']) && $featureFlags['admin_latte_render']) {
     // new version since 0.4.7 or higer
     $admin->renderAdmin();

--- a/dist/classes/Admin.php
+++ b/dist/classes/Admin.php
@@ -37,6 +37,7 @@ class Admin extends MyAdmin
     /**
      * @var array<array<string>> tables and columns to search in admin
      * table => [id, field1 to be searched in, field2 to be searched in...]
+     * TODO move to config.php
      */
     protected $searchColumns = [
         'category' => ['id', 'name_#', 'content_#'], // "#" will be replaced by current language
@@ -58,7 +59,10 @@ class Admin extends MyAdmin
     /**
      * Output (in HTML) the project-specific links in the navigation section of admin
      * TODO: navázat na další features
+     * TODO: move to template/admin-special-menu-links.latte
      *
+     * @deprecated 0.4.7 Set `$featureFlags['admin_latte_render'] = true;` instead.
+     * @see template/admin-special-menu-links.latte
      * @return string
      */
     protected function outputSpecialMenuLinks()
@@ -833,7 +837,7 @@ class Admin extends MyAdmin
     /**
      * As vendor folder has usually denied access from browser,
      * the content of the standard admin.css MUST be available through this method
-     * LEGACY
+     * @deprecated 0.4.7 Set `$featureFlags['admin_latte_render'] = true;` instead.
      *
      * @return string
      */

--- a/dist/classes/App.php
+++ b/dist/classes/App.php
@@ -166,6 +166,7 @@ class App extends MyCommon
 
         $this->MyCMS->renderLatte(
             DIR_TEMPLATE_CACHE,
+            //[$customFilters, 'loader'], // TODO use this with $Latte->addFilterLoader($this->customFilters)
             [$customFilters, 'common'],
             array_merge(
                 [

--- a/dist/composer.json
+++ b/dist/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "require": {
         "php": "^5.6|^7.0",
-        "workofstan/mycms": "dev-notest/admin-ui2",
+        "workofstan/mycms": "dev-feature/admin-ui2",
         "robmorgan/phinx": "^0.10.6|^0.12.3",
         "swiftmailer/swiftmailer": "^5.4|^6.2",
         "webmozart/assert": "^1.9.1",

--- a/dist/composer.json
+++ b/dist/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "require": {
         "php": "^5.6|^7.0",
-        "workofstan/mycms": "dev-feature/admin-ui2",
+        "workofstan/mycms": "dev-main",
         "robmorgan/phinx": "^0.10.6|^0.12.3",
         "swiftmailer/swiftmailer": "^5.4|^6.2",
         "webmozart/assert": "^1.9.1",

--- a/dist/composer.json
+++ b/dist/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "require": {
         "php": "^5.6|^7.0",
-        "workofstan/mycms": "dev-main",
+        "workofstan/mycms": "dev-notest/admin-ui2",
         "robmorgan/phinx": "^0.10.6|^0.12.3",
         "swiftmailer/swiftmailer": "^5.4|^6.2",
         "webmozart/assert": "^1.9.1",

--- a/dist/template/admin-special-menu-links.latte
+++ b/dist/template/admin-special-menu-links.latte
@@ -5,18 +5,19 @@
 {* TODO enrich inherited $switches *}
 
             {* A Produkty k řazení *}
-            <li n:if="!$featureFlags['order_hierarchy']" class="nav-item' . (isset($_GET['products']) ? ' active' : '')
-            . '"><a href="?products" class="nav-link"><i class="fas fa-gift"></i> '
+            <li n:if="!$featureFlags['order_hierarchy']" class="nav-item
+{if in_array('products', $switches)} active{/if}"><a href="?products" class="nav-link"><i class="fas fa-gift"></i> '
             {="Products"|translate}</a></li>
 
             {* A Stránky k řazení *}
-            <li n:if="!$featureFlags['order_hierarchy']" class="nav-item' . (isset($_GET['pages']) ? ' active' : '')
-            . '"><a href="?pages" class="nav-link"><i class="far fa-file-alt"></i> '
+            <li n:if="!$featureFlags['order_hierarchy']" class="nav-item
+{if in_array('pages', $switches)} active{/if}">
+            <a href="?pages" class="nav-link"><i class="far fa-file-alt"></i> '
             {="Pages"|translate}</a></li>
             
             {* URLs - (Friendly URL set-up and) check duplicities *}
-            <li class="nav-item' . (isset($_GET['urls']) ? ' active' : '')
-            . '"><a href="?urls" class="nav-link"><i class="fas fa-unlink"></i> URL</a></li>
+            <li class="nav-item
+{if in_array('urls', $switches)} active{/if}"><a href="?urls" class="nav-link"><i class="fas fa-unlink"></i> URL</a></li>
             
             {* F Divize a produkty k řazení (jako A Produkty k řazení) *}
             <li n:if="!$featureFlags['order_hierarchy']" class="nav-item"><a href="?divisions-products" class="nav-link'

--- a/dist/template/admin-special-menu-links.latte
+++ b/dist/template/admin-special-menu-links.latte
@@ -1,0 +1,40 @@
+{* the project-specific links in the navigation section of admin *}
+{* TODO: navázat na další features *}
+
+
+{* TODO enrich inherited $switches *}
+
+            {* A Produkty k řazení *}
+            <li n:if="!$featureFlags['order_hierarchy']" class="nav-item' . (isset($_GET['products']) ? ' active' : '')
+            . '"><a href="?products" class="nav-link"><i class="fas fa-gift"></i> '
+            {="Products"|translate}</a></li>
+
+            {* A Stránky k řazení *}
+            <li n:if="!$featureFlags['order_hierarchy']" class="nav-item' . (isset($_GET['pages']) ? ' active' : '')
+            . '"><a href="?pages" class="nav-link"><i class="far fa-file-alt"></i> '
+            {="Pages"|translate}</a></li>
+            
+            {* URLs - (Friendly URL set-up and) check duplicities *}
+            <li class="nav-item' . (isset($_GET['urls']) ? ' active' : '')
+            . '"><a href="?urls" class="nav-link"><i class="fas fa-unlink"></i> URL</a></li>
+            
+            {* F Divize a produkty k řazení (jako A Produkty k řazení) *}
+            <li n:if="!$featureFlags['order_hierarchy']" class="nav-item"><a href="?divisions-products" class="nav-link'
+            . (isset($_GET['divisions-products']) ? ' active' : '') .
+            '"><i class="fa fa-gift mr-1" aria-hidden="true"></i>
+            {="Divisions and products"|translate}</a></li>
+            {* F drop-down menu *}
+            <li class="nav-item dropdown"><a class="nav-link dropdown-toggle'
+            . (isset($_GET['urls']) || isset($_GET['translations']) ? ' active' : '')
+            " href="#" id="navbarDropdown" role="button" data-toggle="dropdown"
+            aria-haspopup="true" aria-expanded="true"><i class="fas fa-lightbulb"></i></a>
+            <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                {* URLs - Friendly URL set-up (and check duplicities) *}
+                <a href="?urls" class="dropdown-item' . (isset($_GET['urls']) ? ' active' : '')
+                . '"><i class="fa fa-link mr-1" aria-hidden="true"></i> '
+                {="Friendly URL"|translate}</a>'
+                {* F Překlady *}
+                <a href="?translations" class="dropdown-item' . (isset($_GET['translations']) ? ' active' : '')
+                "><i class="fa fa-globe mr-1" aria-hidden="true"></i>
+                {="Translations"|translate}</a>
+            </div></li>

--- a/dist/template/admin-special-menu-links.latte
+++ b/dist/template/admin-special-menu-links.latte
@@ -2,38 +2,25 @@
 {* TODO: navázat na další features *}
 
             {* A Produkty k řazení *}
-            <li n:if="!$featureFlags['order_hierarchy']" class="nav-item
-{if in_array('products', $switches)} active{/if}"><a href="?products" class="nav-link"><i class="fas fa-gift"></i> '
+            <li n:if="$featureFlags['order_hierarchy']" class="nav-item{if in_array('products', $switches)} active{/if}"><a href="?products" class="nav-link"><i class="fas fa-gift"></i>
             {="Products"|translate}</a></li>
 
             {* A Stránky k řazení *}
-            <li n:if="!$featureFlags['order_hierarchy']" class="nav-item
-{if in_array('pages', $switches)} active{/if}">
-            <a href="?pages" class="nav-link"><i class="far fa-file-alt"></i> '
-            {="Pages"|translate}</a></li>
+            <li n:if="$featureFlags['order_hierarchy']" class="nav-item{if in_array('pages', $switches)} active{/if}"><a href="?pages" class="nav-link"><i class="far fa-file-alt"></i>{="Pages"|translate}</a></li>
             
             {* URLs - (Friendly URL set-up and) check duplicities *}
-            <li class="nav-item
-{if in_array('urls', $switches)} active{/if}"><a href="?urls" class="nav-link"><i class="fas fa-unlink"></i> URL</a></li>
+            <li class="nav-item{if in_array('urls', $switches)} active{/if}"><a href="?urls" class="nav-link"><i class="fas fa-unlink"></i> URL</a></li>
             
             {* F Divize a produkty k řazení (jako A Produkty k řazení) *}
-            <li n:if="!$featureFlags['order_hierarchy']" class="nav-item"><a href="?divisions-products" class="nav-link'
-{if in_array('divisions-products', $switches)} active{/if}">            
-            <i class="fa fa-gift mr-1" aria-hidden="true"></i>
-            {="Divisions and products"|translate}</a></li>
+            <li n:if="$featureFlags['order_hierarchy']" class="nav-item"><a href="?divisions-products" class="nav-link{if in_array('divisions-products', $switches)} active{/if}"><i class="fa fa-gift mr-1" aria-hidden="true"></i>{="Divisions and products"|translate}</a></li>
             {* F drop-down menu *}
             <li class="nav-item dropdown"><a class="nav-link dropdown-toggle{if in_array('translations', $switches) || in_array('urls', $switches)} active{/if}"
-            href="#" id="navbarDropdown" role="button" data-toggle="dropdown"
-            aria-haspopup="true" aria-expanded="true"><i class="fas fa-lightbulb"></i></a>
-            <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                {* URLs - Friendly URL set-up (and check duplicities) *}
-                <a href="?urls" class="dropdown-item
-{if in_array('urls', $switches)} active{/if}">
-                <i class="fa fa-link mr-1" aria-hidden="true"></i> '
-                {="Friendly URL"|translate}</a>'
-                {* F Překlady *}
-                <a href="?translations" class="dropdown-item
-{if in_array('translations', $switches)} active{/if}">
-                <i class="fa fa-globe mr-1" aria-hidden="true"></i>
-                {="Translations"|translate}</a>
-            </div></li>
+                href="#" id="navbarDropdown" role="button" data-toggle="dropdown"
+                aria-haspopup="true" aria-expanded="true"><i class="fas fa-lightbulb"></i></a>
+                <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                    {* URLs - Friendly URL set-up (and check duplicities) *}
+                    <a href="?urls" class="dropdown-item{if in_array('urls', $switches)} active{/if}"><i class="fa fa-link mr-1" aria-hidden="true"></i>{="Friendly URL"|translate}</a>
+                    {* F Překlady *}
+                    <a href="?translations" class="dropdown-item{if in_array('translations', $switches)} active{/if}"><i class="fa fa-globe mr-1" aria-hidden="true"></i>{="Translations"|translate}</a>
+                </div>
+            </li>

--- a/dist/template/admin-special-menu-links.latte
+++ b/dist/template/admin-special-menu-links.latte
@@ -1,9 +1,6 @@
 {* the project-specific links in the navigation section of admin *}
 {* TODO: navázat na další features *}
 
-
-{* TODO enrich inherited $switches *}
-
             {* A Produkty k řazení *}
             <li n:if="!$featureFlags['order_hierarchy']" class="nav-item
 {if in_array('products', $switches)} active{/if}"><a href="?products" class="nav-link"><i class="fas fa-gift"></i> '
@@ -25,9 +22,8 @@
             <i class="fa fa-gift mr-1" aria-hidden="true"></i>
             {="Divisions and products"|translate}</a></li>
             {* F drop-down menu *}
-            <li class="nav-item dropdown"><a class="nav-link dropdown-toggle'
-            . (isset($_GET['urls']) || isset($_GET['translations']) ? ' active' : '')
-            " href="#" id="navbarDropdown" role="button" data-toggle="dropdown"
+            <li class="nav-item dropdown"><a class="nav-link dropdown-toggle{if in_array('translations', $switches) || in_array('urls', $switches)} active{/if}"
+            href="#" id="navbarDropdown" role="button" data-toggle="dropdown"
             aria-haspopup="true" aria-expanded="true"><i class="fas fa-lightbulb"></i></a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                 {* URLs - Friendly URL set-up (and check duplicities) *}

--- a/dist/template/admin-special-menu-links.latte
+++ b/dist/template/admin-special-menu-links.latte
@@ -21,8 +21,8 @@
             
             {* F Divize a produkty k řazení (jako A Produkty k řazení) *}
             <li n:if="!$featureFlags['order_hierarchy']" class="nav-item"><a href="?divisions-products" class="nav-link'
-            . (isset($_GET['divisions-products']) ? ' active' : '') .
-            '"><i class="fa fa-gift mr-1" aria-hidden="true"></i>
+{if in_array('divisions-products', $switches)} active{/if}">            
+            <i class="fa fa-gift mr-1" aria-hidden="true"></i>
             {="Divisions and products"|translate}</a></li>
             {* F drop-down menu *}
             <li class="nav-item dropdown"><a class="nav-link dropdown-toggle'
@@ -31,11 +31,13 @@
             aria-haspopup="true" aria-expanded="true"><i class="fas fa-lightbulb"></i></a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                 {* URLs - Friendly URL set-up (and check duplicities) *}
-                <a href="?urls" class="dropdown-item' . (isset($_GET['urls']) ? ' active' : '')
-                . '"><i class="fa fa-link mr-1" aria-hidden="true"></i> '
+                <a href="?urls" class="dropdown-item
+{if in_array('urls', $switches)} active{/if}">
+                <i class="fa fa-link mr-1" aria-hidden="true"></i> '
                 {="Friendly URL"|translate}</a>'
                 {* F Překlady *}
-                <a href="?translations" class="dropdown-item' . (isset($_GET['translations']) ? ' active' : '')
-                "><i class="fa fa-globe mr-1" aria-hidden="true"></i>
+                <a href="?translations" class="dropdown-item
+{if in_array('translations', $switches)} active{/if}">
+                <i class="fa fa-globe mr-1" aria-hidden="true"></i>
                 {="Translations"|translate}</a>
             </div></li>

--- a/template/@admin.latte
+++ b/template/@admin.latte
@@ -2,10 +2,10 @@
 <html lang="{$language}">
 {include 'inherite.latte', latte => 'admin-head.latte'}
     <body>
-        {*
         <header>
             {include 'admin-navigation.latte'}
         </header>
+        {*
         <div class="container-fluid row">
             {include 'admin-user-agendas.latte'}
         </div>

--- a/template/@admin.latte
+++ b/template/@admin.latte
@@ -4,10 +4,10 @@
     <body>
         {*
         <header>
-            {include 'navigation.latte'}
+            {include 'admin-navigation.latte'}
         </header>
         <div class="container-fluid row">
-            {include 'user-agendas.latte'}
+            {include 'admin-user-agendas.latte'}
         </div>
         *}
         {block htmlbody}{/block}

--- a/template/admin-head.latte
+++ b/template/admin-head.latte
@@ -1,4 +1,4 @@
-{* required: $pageTitle, $HTMLHeaders, $clientSideResources['css'] *}
+{* required: $clientSideResources['css'], $featureFlags, $HTMLHeaders, $pageTitle *}
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -9,5 +9,8 @@
         <title>{$pageTitle ? $pageTitle . " · " : ""}CMS Admin</title>
         {foreach $clientSideResources['css'] as $cssUri}
         <link rel="stylesheet" href="{$cssUri}" />
-        {/foreach}  
+        {/foreach}
+        <script>
+            var FEATURE_FLAGS = {$featureFlags};
+        </script>
     </head>

--- a/template/admin-navigation.latte
+++ b/template/admin-navigation.latte
@@ -1,52 +1,43 @@
-{* the navigation section of admin *}
-<nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
-    <a class="nav-item mr-2" href="' . Tools::h($_SERVER['SCRIPT_NAME']) . '" title="{="Dashboard"|translate}"><i class="fa fa-tachometer-alt"></i></a>
-    <button class="btn btn-secondary btn-sm" title="{="Search"|translate}" type="submit" id="nav-search-button"><i class="fa fa-search"></i></button>
-    <a data-toggle="popover" data-trigger="focus" title="" data-content="" id="realtime-message" data-placement="bottom" tabindex="0"></a>
-    <button class="navbar-toggler d-lg-none" type="button" data-toggle="collapse" aria-expanded="false" data-target="#navbar-content" aria-controls="navbar-content"><span class="navbar-toggler-icon mr-1"></span></button>
-    <div class="collapse navbar-collapse" id="navbar-content">
-        <ul class="navbar-nav mr-auto">
-        {if $authUser}
-            {include 'inherite.latte', latte => 'admin-special-menu-links.latte'}
-            <li class="nav-item' . (isset($_GET['media']) ? ' active' : '') . '"><a href="?media" class="nav-link"><i class="fa fa-video"></i> {="Media"|translate}</a></li>
-            <li class="nav-item dropdown' . (isset($_GET['user']) ? ' active' : '') . '">
-                <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="{="User"|translate}"><i class="fa fa-user"></i> {="User"|translate}</a>
-                <div class="dropdown-menu" aria-labelledby="navbarDropdown" id="user-dropdown-menu">
-                    <a href="" class="dropdown-item disabled"><i class="fa fa-user"></i> {$username}</a>
-                    <div class="dropdown-divider"></div>
-                    <a class="dropdown-item' . (isset($_GET['logout']) ? ' active' : '') . '" href="?user&amp;logout"><i class="fa fa-sign-out-alt mr-1"></i> {="Logout"|translate}</a>
-                    <a class="dropdown-item' . (isset($_GET['change-password']) ? ' active' : '') . '" href="?user&amp;change-password"><i class="fa fa-id-card mr-1"></i> {="Change password"|translate}</a>
-                    <a class="dropdown-item' . (isset($_GET['create-user']) ? ' active' : '') . '" href="?user&amp;create-user"><i class="fa fa-user-plus mr-1"></i> {="Create user"|translate}</a>
-                    <a class="dropdown-item' . (isset($_GET['delete-user']) ? ' active' : '') . '" href="?user&amp;delete-user"><i class="fa fa-user-times mr-1"></i> {="Delete user"|translate}</a>
+{* the navigation section of admin; required $language, $searchString, $switches, $translations, $username *}
+            <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
+                <a class="nav-item mr-2" href="admin.php"{* orignally more universal Tools::h($_SERVER['SCRIPT_NAME']) was used *} title="{="Dashboard"|translate}"><i class="fa fa-tachometer-alt"></i></a>
+                <button class="btn btn-secondary btn-sm" title="{="Search"|translate}" type="submit" id="nav-search-button"><i class="fa fa-search"></i></button>
+                <a data-toggle="popover" data-trigger="focus" title="" data-content="" id="realtime-message" data-placement="bottom" tabindex="0"></a>
+                <button class="navbar-toggler d-lg-none" type="button" data-toggle="collapse" aria-expanded="false" data-target="#navbar-content" aria-controls="navbar-content"><span class="navbar-toggler-icon mr-1"></span></button>
+                <div class="collapse navbar-collapse" id="navbar-content">
+                    <ul class="navbar-nav mr-auto">
+                    {if $authUser}
+                        {include 'inherite.latte', latte => 'admin-special-menu-links.latte'}
+                        <li class="nav-item{if in_array('media', $switches)} active{/if}"><a href="?media" class="nav-link"><i class="fa fa-video"></i> {="Media"|translate}</a></li>
+                        <li class="nav-item dropdown{if in_array('user', $switches)} active{/if}">
+                            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="{="User"|translate}"><i class="fa fa-user"></i> {="User"|translate}</a>
+                            <div class="dropdown-menu" aria-labelledby="navbarDropdown" id="user-dropdown-menu">
+                                <a href="" class="dropdown-item disabled"><i class="fa fa-user"></i> {$username}</a>
+                                <div class="dropdown-divider"></div>
+                                <a class="dropdown-item{if in_array('logout', $switches)} active{/if}" href="?user&amp;logout"><i class="fa fa-sign-out-alt mr-1"></i> {="Logout"|translate}</a>
+                                <a class="dropdown-item{if in_array('change-password', $switches)} active{/if}" href="?user&amp;change-password"><i class="fa fa-id-card mr-1"></i> {="Change password"|translate}</a>
+                                <a class="dropdown-item{if in_array('create-user', $switches)} active{/if}" href="?user&amp;create-user"><i class="fa fa-user-plus mr-1"></i> {="Create user"|translate}</a>
+                                <a class="dropdown-item{if in_array('delete-user', $switches)} active{/if}" href="?user&amp;delete-user"><i class="fa fa-user-times mr-1"></i> {="Delete user"|translate}</a>
+                            </div>
+                        </li>
+                    {/if}
+                        <li class="nav-item dropdown">
+                            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="{="Settings"|translate}"><i class="fa fa-cog"></i> {="Settings"|translate}</a>
+                            <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                            {foreach $translations as $key => $value}
+                                <a class="dropdown-item{if $key == $language} active{/if}" href="?language={$key}"{* originally more complex Tools::urlChange(['language' => $key]) was used *}><i class="fa fa-language mr-1"></i> {$value}</a>
+                            {/foreach}
+                            {if $authUser}
+                                {*         //TODO fix following code, that hides sidebar but leaves the vertical line and narrows the content view
+                                        //<div class="dropdown-divider"></div><a class="dropdown-item" href="" id="toggle-nav" title="{="Toggle sidebar"|translate}"><i class="fa fa-columns mr-1"></i> {="Sidebar"|translate}</a>
+                                *}
+                                {include 'inherite.latte', latte => 'admin-special-settings-links.latte'}
+                            {/if}
+                            </div>
+                        </li>
+                    </ul>
                 </div>
-            </li>
-        {/if}
-            <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="{="Settings"|translate}"><i class="fa fa-cog"></i> {="Settings"|translate}</a>
-                <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                {foreach $this->tableAdmin->TRANSLATIONS as $key => $value}
-                    <a class="dropdown-item' . ($key == $_SESSION['language'] ? ' active' : '') . '" href="?' . Tools::urlChange(['language' => $key]) . '"><i class="fa fa-language mr-1"></i> ' . Tools::h($value) . </a>
-                {/foreach}
-                {if $authUser}
-                    {*         //TODO fix following code, that hides sidebar but leaves the vertical line and narrows the content view
-                            //<div class="dropdown-divider"></div><a class="dropdown-item" href="" id="toggle-nav" title="{="Toggle sidebar"|translate}"><i class="fa fa-columns mr-1"></i> {="Sidebar"|translate}</a>
-                    *}
-                    {include 'inherite.latte', latte => 'admin-special-settings-links.latte'}
-                {/if}
-                </div>
-            </li>
-        </ul>
-    </div>
-
-{* todo really replaced ??? if $authUser *}
-    <form n:if="$authUser" class="collapse mt-md-0" id="nav-search-form">
-        Tools::htmlInput(
-            'search',
-            '',
-            Tools::set($_GET['search'], ''),
-            ['class' => 'form-control', 'placeholder' => $this->tableAdmin->translate('Search'), 'required' => true, 'id' => 'nav-search-input']
-        )
-    </form>
-{* /if *}
-
-</nav>
+                <form n:if="$authUser" class="collapse mt-md-0" id="nav-search-form">
+                    <input class="form-control" placeholder="{="Search"|translate}" required id="nav-search-input" type="text" name="search" value="{$searchString}"/>
+                </form>
+            </nav>

--- a/template/admin-navigation.latte
+++ b/template/admin-navigation.latte
@@ -1,0 +1,53 @@
+{* the navigation section of admin *} <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
+                <a class="nav-item mr-2" href="' . Tools::h($_SERVER['SCRIPT_NAME']) . '" title="' . $this->tableAdmin->translate('Dashboard') . '"><i class="fa fa-tachometer-alt"></i></a>
+                <button class="btn btn-secondary btn-sm" title="' . $this->tableAdmin->translate('Search') . '" type="submit" id="nav-search-button"><i class="fa fa-search"></i></button>
+                <a data-toggle="popover" data-trigger="focus" title="" data-content="" id="realtime-message" data-placement="bottom" tabindex="0"></a>
+                <button class="navbar-toggler d-lg-none" type="button" data-toggle="collapse" aria-expanded="false" data-target="#navbar-content" aria-controls="navbar-content"><span class="navbar-toggler-icon mr-1"></span></button>
+                <div class="collapse navbar-collapse" id="navbar-content">
+                    <ul class="navbar-nav mr-auto">
+
+{if $authUser}
+      {include 'inherite.latte', latte => 'admin-special-menu-links.latte'}
+                <li class="nav-item' . (isset($_GET['media']) ? ' active' : '') . '"><a href="?media" class="nav-link"><i class="fa fa-video"></i> ' . $this->tableAdmin->translate('Media') . '</a></li>
+                <li class="nav-item dropdown' . (isset($_GET['user']) ? ' active' : '') . '">
+                <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="' . $this->tableAdmin->translate('User') . '"><i class="fa fa-user"></i> ' . $this->tableAdmin->translate('User') . '</a>
+                <div class="dropdown-menu" aria-labelledby="navbarDropdown" id="user-dropdown-menu">
+                  <a href="" class="dropdown-item disabled"><i class="fa fa-user"></i> ' . Tools::h($_SESSION['user']) . '</a>
+                  <div class="dropdown-divider"></div>
+                  <a class="dropdown-item' . (isset($_GET['logout']) ? ' active' : '') . '" href="?user&amp;logout"><i class="fa fa-sign-out-alt mr-1"></i> ' . $this->tableAdmin->translate('Logout') . '</a>
+                  <a class="dropdown-item' . (isset($_GET['change-password']) ? ' active' : '') . '" href="?user&amp;change-password"><i class="fa fa-id-card mr-1"></i> ' . $this->tableAdmin->translate('Change password') . '</a>
+                  <a class="dropdown-item' . (isset($_GET['create-user']) ? ' active' : '') . '" href="?user&amp;create-user"><i class="fa fa-user-plus mr-1"></i> ' . $this->tableAdmin->translate('Create user') . '</a>
+                  <a class="dropdown-item' . (isset($_GET['delete-user']) ? ' active' : '') . '" href="?user&amp;delete-user"><i class="fa fa-user-times mr-1"></i> ' . $this->tableAdmin->translate('Delete user') . '</a>
+                </div>
+              </li>
+        }
+{/if}
+        <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="' . $this->tableAdmin->translate('Settings') . '"><i class="fa fa-cog"></i> ' . $this->tableAdmin->translate('Settings') . '</a>
+            <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+
+        {foreach $this->tableAdmin->TRANSLATIONS as $key => $value}
+            <a class="dropdown-item' . ($key == $_SESSION['language'] ? ' active' : '') . '" href="?' . Tools::urlChange(['language' => $key]) . '"><i class="fa fa-language mr-1"></i> ' . Tools::h($value) . </a>
+         {/foreach}
+
+
+{if $authUser}
+       {*         //TODO fix following code, that hides sidebar but leaves the vertical line and narrows the content view
+                //<div class="dropdown-divider"></div><a class="dropdown-item" href="" id="toggle-nav" title="' . Tools::h($this->tableAdmin->translate('Toggle sidebar')) . '"><i class="fa fa-columns mr-1"></i> ' . $this->tableAdmin->translate('Sidebar') . '</a>' .            
+    *}  {include 'inherite.latte', latte => 'admin-special-settings-links.latte'}
+{/if}
+        </div></li></ul></div>
+
+
+{if $authUser}
+            <form class="collapse mt-md-0" id="nav-search-form">
+                Tools::htmlInput(
+                    'search',
+                    '',
+                    Tools::set($_GET['search'], ''),
+                    ['class' => 'form-control', 'placeholder' => $this->tableAdmin->translate('Search'), 'required' => true, 'id' => 'nav-search-input']
+                )
+                </form>        
+{/if}
+
+        </nav>

--- a/template/admin-navigation.latte
+++ b/template/admin-navigation.latte
@@ -1,54 +1,52 @@
-{* the navigation section of admin *} <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
-<a class="nav-item mr-2" href="' . Tools::h($_SERVER['SCRIPT_NAME']) . '" title="{="Dashboard"|translate}"><i class="fa fa-tachometer-alt"></i></a>
-<button class="btn btn-secondary btn-sm" title="{="Search"|translate}" type="submit" id="nav-search-button"><i class="fa fa-search"></i></button>
-<a data-toggle="popover" data-trigger="focus" title="" data-content="" id="realtime-message" data-placement="bottom" tabindex="0"></a>
-<button class="navbar-toggler d-lg-none" type="button" data-toggle="collapse" aria-expanded="false" data-target="#navbar-content" aria-controls="navbar-content"><span class="navbar-toggler-icon mr-1"></span></button>
-<div class="collapse navbar-collapse" id="navbar-content">
-    <ul class="navbar-nav mr-auto">
-
-{if $authUser}
-      {include 'inherite.latte', latte => 'admin-special-menu-links.latte'}
-                <li class="nav-item' . (isset($_GET['media']) ? ' active' : '') . '"><a href="?media" class="nav-link"><i class="fa fa-video"></i> {="Media"|translate}</a></li>
-                <li class="nav-item dropdown' . (isset($_GET['user']) ? ' active' : '') . '">
+{* the navigation section of admin *}
+<nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
+    <a class="nav-item mr-2" href="' . Tools::h($_SERVER['SCRIPT_NAME']) . '" title="{="Dashboard"|translate}"><i class="fa fa-tachometer-alt"></i></a>
+    <button class="btn btn-secondary btn-sm" title="{="Search"|translate}" type="submit" id="nav-search-button"><i class="fa fa-search"></i></button>
+    <a data-toggle="popover" data-trigger="focus" title="" data-content="" id="realtime-message" data-placement="bottom" tabindex="0"></a>
+    <button class="navbar-toggler d-lg-none" type="button" data-toggle="collapse" aria-expanded="false" data-target="#navbar-content" aria-controls="navbar-content"><span class="navbar-toggler-icon mr-1"></span></button>
+    <div class="collapse navbar-collapse" id="navbar-content">
+        <ul class="navbar-nav mr-auto">
+        {if $authUser}
+            {include 'inherite.latte', latte => 'admin-special-menu-links.latte'}
+            <li class="nav-item' . (isset($_GET['media']) ? ' active' : '') . '"><a href="?media" class="nav-link"><i class="fa fa-video"></i> {="Media"|translate}</a></li>
+            <li class="nav-item dropdown' . (isset($_GET['user']) ? ' active' : '') . '">
                 <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="{="User"|translate}"><i class="fa fa-user"></i> {="User"|translate}</a>
                 <div class="dropdown-menu" aria-labelledby="navbarDropdown" id="user-dropdown-menu">
-                  <a href="" class="dropdown-item disabled"><i class="fa fa-user"></i> ' . Tools::h($_SESSION['user']) . '</a>
-                  <div class="dropdown-divider"></div>
-                  <a class="dropdown-item' . (isset($_GET['logout']) ? ' active' : '') . '" href="?user&amp;logout"><i class="fa fa-sign-out-alt mr-1"></i> {="Logout"|translate}</a>
-                  <a class="dropdown-item' . (isset($_GET['change-password']) ? ' active' : '') . '" href="?user&amp;change-password"><i class="fa fa-id-card mr-1"></i> {="Change password"|translate}</a>
-                  <a class="dropdown-item' . (isset($_GET['create-user']) ? ' active' : '') . '" href="?user&amp;create-user"><i class="fa fa-user-plus mr-1"></i> {="Create user"|translate}</a>
-                  <a class="dropdown-item' . (isset($_GET['delete-user']) ? ' active' : '') . '" href="?user&amp;delete-user"><i class="fa fa-user-times mr-1"></i> {="Delete user"|translate}</a>
+                    <a href="" class="dropdown-item disabled"><i class="fa fa-user"></i> {$username}</a>
+                    <div class="dropdown-divider"></div>
+                    <a class="dropdown-item' . (isset($_GET['logout']) ? ' active' : '') . '" href="?user&amp;logout"><i class="fa fa-sign-out-alt mr-1"></i> {="Logout"|translate}</a>
+                    <a class="dropdown-item' . (isset($_GET['change-password']) ? ' active' : '') . '" href="?user&amp;change-password"><i class="fa fa-id-card mr-1"></i> {="Change password"|translate}</a>
+                    <a class="dropdown-item' . (isset($_GET['create-user']) ? ' active' : '') . '" href="?user&amp;create-user"><i class="fa fa-user-plus mr-1"></i> {="Create user"|translate}</a>
+                    <a class="dropdown-item' . (isset($_GET['delete-user']) ? ' active' : '') . '" href="?user&amp;delete-user"><i class="fa fa-user-times mr-1"></i> {="Delete user"|translate}</a>
                 </div>
-              </li>
-        }
-{/if}
-        <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="{="Settings"|translate}"><i class="fa fa-cog"></i> {="Settings"|translate}</a>
-            <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+            </li>
+        {/if}
+            <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="{="Settings"|translate}"><i class="fa fa-cog"></i> {="Settings"|translate}</a>
+                <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                {foreach $this->tableAdmin->TRANSLATIONS as $key => $value}
+                    <a class="dropdown-item' . ($key == $_SESSION['language'] ? ' active' : '') . '" href="?' . Tools::urlChange(['language' => $key]) . '"><i class="fa fa-language mr-1"></i> ' . Tools::h($value) . </a>
+                {/foreach}
+                {if $authUser}
+                    {*         //TODO fix following code, that hides sidebar but leaves the vertical line and narrows the content view
+                            //<div class="dropdown-divider"></div><a class="dropdown-item" href="" id="toggle-nav" title="{="Toggle sidebar"|translate}"><i class="fa fa-columns mr-1"></i> {="Sidebar"|translate}</a>
+                    *}
+                    {include 'inherite.latte', latte => 'admin-special-settings-links.latte'}
+                {/if}
+                </div>
+            </li>
+        </ul>
+    </div>
 
-        {foreach $this->tableAdmin->TRANSLATIONS as $key => $value}
-            <a class="dropdown-item' . ($key == $_SESSION['language'] ? ' active' : '') . '" href="?' . Tools::urlChange(['language' => $key]) . '"><i class="fa fa-language mr-1"></i> ' . Tools::h($value) . </a>
-        {/foreach}
-
-
-{if $authUser}
-    {*         //TODO fix following code, that hides sidebar but leaves the vertical line and narrows the content view
-            //<div class="dropdown-divider"></div><a class="dropdown-item" href="" id="toggle-nav" title="{="Toggle sidebar"|translate}"><i class="fa fa-columns mr-1"></i> {="Sidebar"|translate}</a>
-    *}
-    {include 'inherite.latte', latte => 'admin-special-settings-links.latte'}
-{/if}
-        </div></li></ul></div>
-
-
-{if $authUser}
-            <form class="collapse mt-md-0" id="nav-search-form">
-                Tools::htmlInput(
-                    'search',
-                    '',
-                    Tools::set($_GET['search'], ''),
-                    ['class' => 'form-control', 'placeholder' => $this->tableAdmin->translate('Search'), 'required' => true, 'id' => 'nav-search-input']
-                )
-            </form>
-{/if}
+{* todo really replaced ??? if $authUser *}
+    <form n:if="$authUser" class="collapse mt-md-0" id="nav-search-form">
+        Tools::htmlInput(
+            'search',
+            '',
+            Tools::set($_GET['search'], ''),
+            ['class' => 'form-control', 'placeholder' => $this->tableAdmin->translate('Search'), 'required' => true, 'id' => 'nav-search-input']
+        )
+    </form>
+{* /if *}
 
 </nav>

--- a/template/admin-navigation.latte
+++ b/template/admin-navigation.latte
@@ -1,40 +1,41 @@
 {* the navigation section of admin *} <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
-                <a class="nav-item mr-2" href="' . Tools::h($_SERVER['SCRIPT_NAME']) . '" title="' . $this->tableAdmin->translate('Dashboard') . '"><i class="fa fa-tachometer-alt"></i></a>
-                <button class="btn btn-secondary btn-sm" title="' . $this->tableAdmin->translate('Search') . '" type="submit" id="nav-search-button"><i class="fa fa-search"></i></button>
-                <a data-toggle="popover" data-trigger="focus" title="" data-content="" id="realtime-message" data-placement="bottom" tabindex="0"></a>
-                <button class="navbar-toggler d-lg-none" type="button" data-toggle="collapse" aria-expanded="false" data-target="#navbar-content" aria-controls="navbar-content"><span class="navbar-toggler-icon mr-1"></span></button>
-                <div class="collapse navbar-collapse" id="navbar-content">
-                    <ul class="navbar-nav mr-auto">
+<a class="nav-item mr-2" href="' . Tools::h($_SERVER['SCRIPT_NAME']) . '" title="{="Dashboard"|translate}"><i class="fa fa-tachometer-alt"></i></a>
+<button class="btn btn-secondary btn-sm" title="{="Search"|translate}" type="submit" id="nav-search-button"><i class="fa fa-search"></i></button>
+<a data-toggle="popover" data-trigger="focus" title="" data-content="" id="realtime-message" data-placement="bottom" tabindex="0"></a>
+<button class="navbar-toggler d-lg-none" type="button" data-toggle="collapse" aria-expanded="false" data-target="#navbar-content" aria-controls="navbar-content"><span class="navbar-toggler-icon mr-1"></span></button>
+<div class="collapse navbar-collapse" id="navbar-content">
+    <ul class="navbar-nav mr-auto">
 
 {if $authUser}
       {include 'inherite.latte', latte => 'admin-special-menu-links.latte'}
-                <li class="nav-item' . (isset($_GET['media']) ? ' active' : '') . '"><a href="?media" class="nav-link"><i class="fa fa-video"></i> ' . $this->tableAdmin->translate('Media') . '</a></li>
+                <li class="nav-item' . (isset($_GET['media']) ? ' active' : '') . '"><a href="?media" class="nav-link"><i class="fa fa-video"></i> {="Media"|translate}</a></li>
                 <li class="nav-item dropdown' . (isset($_GET['user']) ? ' active' : '') . '">
-                <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="' . $this->tableAdmin->translate('User') . '"><i class="fa fa-user"></i> ' . $this->tableAdmin->translate('User') . '</a>
+                <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="{="User"|translate}"><i class="fa fa-user"></i> {="User"|translate}</a>
                 <div class="dropdown-menu" aria-labelledby="navbarDropdown" id="user-dropdown-menu">
                   <a href="" class="dropdown-item disabled"><i class="fa fa-user"></i> ' . Tools::h($_SESSION['user']) . '</a>
                   <div class="dropdown-divider"></div>
-                  <a class="dropdown-item' . (isset($_GET['logout']) ? ' active' : '') . '" href="?user&amp;logout"><i class="fa fa-sign-out-alt mr-1"></i> ' . $this->tableAdmin->translate('Logout') . '</a>
-                  <a class="dropdown-item' . (isset($_GET['change-password']) ? ' active' : '') . '" href="?user&amp;change-password"><i class="fa fa-id-card mr-1"></i> ' . $this->tableAdmin->translate('Change password') . '</a>
-                  <a class="dropdown-item' . (isset($_GET['create-user']) ? ' active' : '') . '" href="?user&amp;create-user"><i class="fa fa-user-plus mr-1"></i> ' . $this->tableAdmin->translate('Create user') . '</a>
-                  <a class="dropdown-item' . (isset($_GET['delete-user']) ? ' active' : '') . '" href="?user&amp;delete-user"><i class="fa fa-user-times mr-1"></i> ' . $this->tableAdmin->translate('Delete user') . '</a>
+                  <a class="dropdown-item' . (isset($_GET['logout']) ? ' active' : '') . '" href="?user&amp;logout"><i class="fa fa-sign-out-alt mr-1"></i> {="Logout"|translate}</a>
+                  <a class="dropdown-item' . (isset($_GET['change-password']) ? ' active' : '') . '" href="?user&amp;change-password"><i class="fa fa-id-card mr-1"></i> {="Change password"|translate}</a>
+                  <a class="dropdown-item' . (isset($_GET['create-user']) ? ' active' : '') . '" href="?user&amp;create-user"><i class="fa fa-user-plus mr-1"></i> {="Create user"|translate}</a>
+                  <a class="dropdown-item' . (isset($_GET['delete-user']) ? ' active' : '') . '" href="?user&amp;delete-user"><i class="fa fa-user-times mr-1"></i> {="Delete user"|translate}</a>
                 </div>
               </li>
         }
 {/if}
         <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="' . $this->tableAdmin->translate('Settings') . '"><i class="fa fa-cog"></i> ' . $this->tableAdmin->translate('Settings') . '</a>
+            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="{="Settings"|translate}"><i class="fa fa-cog"></i> {="Settings"|translate}</a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdown">
 
         {foreach $this->tableAdmin->TRANSLATIONS as $key => $value}
             <a class="dropdown-item' . ($key == $_SESSION['language'] ? ' active' : '') . '" href="?' . Tools::urlChange(['language' => $key]) . '"><i class="fa fa-language mr-1"></i> ' . Tools::h($value) . </a>
-         {/foreach}
+        {/foreach}
 
 
 {if $authUser}
-       {*         //TODO fix following code, that hides sidebar but leaves the vertical line and narrows the content view
-                //<div class="dropdown-divider"></div><a class="dropdown-item" href="" id="toggle-nav" title="' . Tools::h($this->tableAdmin->translate('Toggle sidebar')) . '"><i class="fa fa-columns mr-1"></i> ' . $this->tableAdmin->translate('Sidebar') . '</a>' .            
-    *}  {include 'inherite.latte', latte => 'admin-special-settings-links.latte'}
+    {*         //TODO fix following code, that hides sidebar but leaves the vertical line and narrows the content view
+            //<div class="dropdown-divider"></div><a class="dropdown-item" href="" id="toggle-nav" title="{="Toggle sidebar"|translate}"><i class="fa fa-columns mr-1"></i> {="Sidebar"|translate}</a>
+    *}
+    {include 'inherite.latte', latte => 'admin-special-settings-links.latte'}
 {/if}
         </div></li></ul></div>
 
@@ -47,7 +48,7 @@
                     Tools::set($_GET['search'], ''),
                     ['class' => 'form-control', 'placeholder' => $this->tableAdmin->translate('Search'), 'required' => true, 'id' => 'nav-search-input']
                 )
-                </form>        
+            </form>
 {/if}
 
-        </nav>
+</nav>

--- a/template/admin-special-menu-links.latte
+++ b/template/admin-special-menu-links.latte
@@ -1,0 +1,1 @@
+{* the project-specific links in the navigation section of admin *}

--- a/template/admin-special-settings-links.latte
+++ b/template/admin-special-settings-links.latte
@@ -1,0 +1,1 @@
+{* the project-specific links in the settings section of admin *}


### PR DESCRIPTION
### Added
- featureFlags to admin-*.latte
- preparation for fixing `Latte::2.11.3 Notice: Engine::addFilter(null, ...) is deprecated, use addFilterLoader()` in PHP/7.1+

### Changed
-  log/translation_missing rotate monthly (not daily)
- dist/admin.php in order to toggle admin menu special links
- MyAdmin::renderAdmin() $switches as parameter of Latté instead of working with $_GET in the template
